### PR TITLE
Implement rendering for files sidebar

### DIFF
--- a/src/components/main/files/mod.rs
+++ b/src/components/main/files/mod.rs
@@ -14,14 +14,14 @@ pub struct Props {
 pub fn Files(cx: Scope<Props>) -> Element {
     let show_new_folder = use_state(&cx, || false);
     let show_upload = use_state(&cx, || false);
-    
+
     cx.render(rsx! {
         div {
             id: "files",
-            sidebar::Sidebar { account: cx.props.account.clone() },
+            sidebar::Sidebar { _account: cx.props.account.clone() },
             div {
                 id: "content",
-                toolbar::Toolbar { 
+                toolbar::Toolbar {
                     on_new_folder: move |_| {
                         show_new_folder.set(true);
                     },

--- a/src/components/main/files/sidebar/mod.rs
+++ b/src/components/main/files/sidebar/mod.rs
@@ -52,8 +52,12 @@ pub fn FileElem(cx: Scope, f: File) -> Element {
 #[allow(non_snake_case)]
 pub fn Folder(cx: Scope, dir: Directory) -> Element {
     let display = use_state(&cx, || FolderDisplay::Closed);
-    let folder_name = &dir.name;
+    let folder_icon: Shape = match *display.current() {
+        FolderDisplay::Open => Shape::FolderOpen,
+        FolderDisplay::Closed => Shape::Folder,
+    };
 
+    let folder_name = &dir.name;
     cx.render(rsx! {
         div {
             class: "tree_folder",
@@ -65,22 +69,9 @@ pub fn Folder(cx: Scope, dir: Directory) -> Element {
                         FolderDisplay::Closed => display.set(FolderDisplay::Open),
                     }
                 },
-                match *display.current() {
-                    FolderDisplay::Open => {
-                        cx.render(rsx!(
-                            Icon {
-                                class: "",
-                                icon: Shape::FolderOpen,
-                            }))
-                    }
-                    FolderDisplay::Closed => {
-                        cx.render(rsx!(
-                            Icon {
-                                class: "",
-                                icon: Shape::Folder,
-                            },
-                        ))
-                    }
+                Icon {
+                    class: "",
+                    icon: folder_icon,
                 },
                 "{folder_name}"
             }
@@ -89,7 +80,7 @@ pub fn Folder(cx: Scope, dir: Directory) -> Element {
             // it requires the else to return the same type. so now both arms of the match return an Option
             match *display.current() {
                 FolderDisplay::Open => {
-                    // need to wrap this in cx.render because cx.render returns an Option
+                    // cx.render returns an Option
                     cx.render(rsx!(
                         dir.contents.iter().map(|item| {
                             // item is referenced by the map
@@ -141,7 +132,7 @@ pub fn Sidebar(cx: Scope, _account: crate::Account) -> Element {
     cx.render(rsx! {
         div {
             id: "sidebar",
-            class: "tree noselect",
+            class: "tree",
             Usage {
                 usage: UsageStats {
                     available: 1256,

--- a/src/components/main/files/sidebar/mod.rs
+++ b/src/components/main/files/sidebar/mod.rs
@@ -32,8 +32,8 @@ pub enum FolderDisplay {
 
 #[inline_props]
 #[allow(non_snake_case)]
-pub fn FileElem(cx: Scope, f: File) -> Element {
-    let name = f.name.clone();
+pub fn FileElem(cx: Scope, file: File) -> Element {
+    let name = file.name.clone();
     cx.render(rsx!(
         a {
             class: "tree_item",
@@ -84,7 +84,7 @@ pub fn Folder(cx: Scope, dir: Directory) -> Element {
                     cx.render(rsx!(
                         dir.contents.iter().map(|item| {
                             match item {
-                                DirItem::File(f) => cx.render(rsx!(FileElem { f: f.clone() })),
+                                DirItem::File(f) => cx.render(rsx!(FileElem { file: f.clone() })),
                                 DirItem::Directory(d) => cx.render(rsx!(Folder { dir: d.clone() })),
                             }
                         })

--- a/src/components/main/files/sidebar/mod.rs
+++ b/src/components/main/files/sidebar/mod.rs
@@ -10,7 +10,7 @@ pub mod usage;
 #[derive(Eq, PartialEq, Clone)]
 pub struct Directory {
     pub name: String,
-    pub contents: Vec<Box<DirItem>>,
+    pub contents: Vec<DirItem>,
 }
 
 #[derive(Eq, PartialEq, Clone)]
@@ -83,10 +83,7 @@ pub fn Folder(cx: Scope, dir: Directory) -> Element {
                     // cx.render returns an Option
                     cx.render(rsx!(
                         dir.contents.iter().map(|item| {
-                            // item is referenced by the map
-                            // the reference is to a Box, so need another deref
-                            // and don't want to move it, so need to borrow
-                            match &**item {
+                            match item {
                                 DirItem::File(f) => cx.render(rsx!(FileElem { f: f.clone() })),
                                 DirItem::Directory(d) => cx.render(rsx!(Folder { dir: d.clone() })),
                             }
@@ -108,23 +105,23 @@ pub fn Sidebar(cx: Scope, _account: crate::Account) -> Element {
     // This is just to work on css
     let subdir_1 = Directory {
         name: "Subdir1".into(),
-        contents: vec![Box::new(DirItem::File(File { name: "f1".into() }))],
+        contents: vec![DirItem::File(File { name: "f1".into() })],
     };
 
     let subdir_3 = Directory {
         name: "Subdir3".into(),
-        contents: vec![Box::new(DirItem::File(File { name: "f2".into() }))],
+        contents: vec![DirItem::File(File { name: "f2".into() })],
     };
     let subdir_2 = Directory {
         name: "Subdir2".into(),
-        contents: vec![Box::new(DirItem::Directory(subdir_3))],
+        contents: vec![DirItem::Directory(subdir_3)],
     };
     let directory = Directory {
         name: "Folder 1".into(),
         contents: vec![
-            Box::new(DirItem::Directory(subdir_1)),
-            Box::new(DirItem::Directory(subdir_2)),
-            Box::new(DirItem::File(File { name: "f3".into() })),
+            DirItem::Directory(subdir_1),
+            DirItem::Directory(subdir_2),
+            DirItem::File(File { name: "f3".into() }),
         ],
     };
 

--- a/src/components/main/files/sidebar/mod.rs
+++ b/src/components/main/files/sidebar/mod.rs
@@ -10,6 +10,147 @@ pub struct Props {
     account: crate::Account,
 }
 
+// want to store all data on heap
+pub type DirectoryRoot = Option<Box<Directory>>;
+
+#[derive(Eq, PartialEq, Clone)]
+// requires a `name` for display purposes and a list of children
+// in the future may want to associate `key` with this so that Dioxus can not re-render stuff
+pub struct Directory {
+    pub name: String,
+    pub contents: Vec<Box<DirItem>>,
+}
+
+#[derive(Eq, PartialEq, Clone)]
+pub struct File {
+    pub name: String,
+}
+
+#[derive(Eq, PartialEq, Clone)]
+pub enum DirItem {
+    File(File),
+    Directory(Directory),
+}
+
+#[derive(Eq, PartialEq, Clone)]
+pub enum FolderDisplay {
+    Open,
+    Closed,
+}
+
+#[allow(non_snake_case)]
+#[inline_props]
+pub fn FileElem(cx: Scope, f: File) -> Element {
+    let name = f.name.clone();
+    cx.render(rsx!(
+        a {
+            class: "tree_item",
+            div {
+                class: "row",
+                Icon {
+                    icon: Shape::Document,
+                },
+                "{name}"
+            },
+        },
+    ))
+}
+
+#[allow(non_snake_case)]
+#[inline_props]
+pub fn Folder(cx: Scope, dir: Directory) -> Element {
+    let display = use_state(&cx, || FolderDisplay::Closed);
+    let folder_name = &dir.name;
+
+    cx.render(rsx! {
+        div {
+            class: "row",
+            onclick: move |_| {
+                match *display.current() {
+                    FolderDisplay::Open => display.set(FolderDisplay::Closed),
+                    FolderDisplay::Closed => display.set(FolderDisplay::Open),
+                }
+            },
+            match *display.current() {
+                FolderDisplay::Open => {
+                    cx.render(rsx!(
+                        Icon {
+                            class: "",
+                            icon: Shape::FolderOpen,
+                        },
+
+                        dir.contents.iter().map(|item| {
+                            // item is referenced by the map
+                            // the reference is to a Box, so need another deref
+                            // and don't want to move it, so need to borrow
+                            match &**item {
+                                DirItem::File(f) => cx.render(rsx!(FileElem{f: f.clone()})),
+                                DirItem::Directory(d) => cx.render(rsx!(Folder{dir: d.clone()})),
+                            }
+                        } )
+                    ))
+                }
+                FolderDisplay::Closed => {
+                    cx.render(rsx!(
+                        Icon {
+                            class: "",
+                            icon: Shape::Folder,
+                        },
+                    ))
+                }
+            },
+            "{folder_name}"
+        }
+    })
+}
+
+#[allow(non_snake_case)]
+pub fn Sidebar(cx: Scope<Props>) -> Element {
+    let subdir_1 = Directory {
+        name: "Subdir1".into(),
+        contents: vec![Box::new(DirItem::File(File { name: "f1".into() }))],
+    };
+    let directory = Directory {
+        name: "Folder 1".into(),
+        contents: vec![
+            Box::new(DirItem::Directory(subdir_1)),
+            Box::new(DirItem::File(File { name: "f2".into() })),
+        ],
+    };
+    cx.render(rsx! {
+        // TODO: This should be generated based on actual content later.
+        // We will create reusable components for a folder and just pass children as data and render
+        // recursively automatically.
+        // This is just to work on css
+        div {
+            id: "sidebar",
+            class: "tree noselect",
+            Usage {
+                usage: UsageStats {
+                    available: 1256,
+                    total: 123456,
+                    used: 122200,
+                    percent_free: 75,
+                }
+            },
+            label {
+                class: "m-top-sm",
+                "Files"
+            },
+            div {
+                class: "tree_wrapper",
+                label {
+                    class: "tree_folder root",
+                }
+                Folder {
+                    dir: directory
+                },
+            }
+        }
+    })
+}
+
+/*
 #[allow(non_snake_case)]
 pub fn Sidebar(cx: Scope<Props>) -> Element {
     cx.render(rsx! {
@@ -202,3 +343,4 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
         }
     })
 }
+*/

--- a/src/components/main/files/sidebar/mod.rs
+++ b/src/components/main/files/sidebar/mod.rs
@@ -111,22 +111,34 @@ pub fn Folder(cx: Scope, dir: Directory) -> Element {
 #[inline_props]
 #[allow(non_snake_case)]
 pub fn Sidebar(cx: Scope, _account: crate::Account) -> Element {
+    // TODO: This should be generated based on actual content later.
+    // We will create reusable components for a folder and just pass children as data and render
+    // recursively automatically.
+    // This is just to work on css
     let subdir_1 = Directory {
         name: "Subdir1".into(),
         contents: vec![Box::new(DirItem::File(File { name: "f1".into() }))],
+    };
+
+    let subdir_3 = Directory {
+        name: "Subdir3".into(),
+        contents: vec![Box::new(DirItem::File(File { name: "f2".into() }))],
+    };
+    let subdir_2 = Directory {
+        name: "Subdir2".into(),
+        contents: vec![Box::new(DirItem::Directory(subdir_3))],
     };
     let directory = Directory {
         name: "Folder 1".into(),
         contents: vec![
             Box::new(DirItem::Directory(subdir_1)),
-            Box::new(DirItem::File(File { name: "f2".into() })),
+            Box::new(DirItem::Directory(subdir_2)),
+            Box::new(DirItem::File(File { name: "f3".into() })),
         ],
     };
+
+    // if multiple folders are desired under `Files`, this could render a list of `DirEntry`
     cx.render(rsx! {
-        // TODO: This should be generated based on actual content later.
-        // We will create reusable components for a folder and just pass children as data and render
-        // recursively automatically.
-        // This is just to work on css
         div {
             id: "sidebar",
             class: "tree noselect",
@@ -154,198 +166,3 @@ pub fn Sidebar(cx: Scope, _account: crate::Account) -> Element {
         }
     })
 }
-
-/*
-#[allow(non_snake_case)]
-pub fn Sidebar(cx: Scope<Props>) -> Element {
-    cx.render(rsx! {
-        // TODO: This should be generated based on actual content later.
-        // We will create reusable components for a folder and just pass children as data and render
-        // recursively automatically.
-        // This is just to work on css
-        div {
-            id: "sidebar",
-            class: "tree noselect",
-            Usage {
-                usage: UsageStats {
-                    available: 1256,
-                    total: 123456,
-                    used: 122200,
-                    percent_free: 75,
-                }
-            },
-            label {
-                class: "m-top-sm",
-                "Files"
-            },
-            div {
-                class: "tree_wrapper",
-                label {
-                    class: "tree_folder root",
-                    div {
-                        class: "row",
-                        Icon {
-                            class: "closed",
-                            icon: Shape::Folder,
-                        },
-                        Icon {
-                            class: "open",
-                            icon: Shape::FolderOpen,
-                        },
-                        "Folder 1"
-                    },
-                    input {
-                        id: "tree_folder_control",
-                        "type": "checkbox",
-                    },
-                    label {
-                        class: "tree_folder",
-                        div {
-                            class: "row",
-                            Icon {
-                                class: "closed",
-                                icon: Shape::Folder,
-                            },
-                            Icon {
-                                class: "open",
-                                icon: Shape::FolderOpen,
-                            },
-                            "SubFolder 1"
-                        },
-                        input {
-                            id: "tree_folder_control",
-                            "type": "checkbox",
-                        },
-                        a {
-                            class: "tree_item",
-                            div {
-                                class: "row",
-                                Icon {
-                                    icon: Shape::Document,
-                                },
-                                "Item"
-                            },
-                        },
-                    },
-                    label {
-                        class: "tree_folder",
-                        div {
-                            class: "row",
-                            Icon {
-                                class: "closed",
-                                icon: Shape::Folder,
-                            },
-                            Icon {
-                                class: "open",
-                                icon: Shape::FolderOpen,
-                            },
-                            "Subfolder 2",
-                        },
-                        input {
-                            id: "tree_folder_control",
-                            "type": "checkbox",
-                        },
-                        label {
-                            class: "tree_folder",
-                            div {
-                                class: "row",
-                                Icon {
-                                    class: "closed",
-                                    icon: Shape::Folder,
-                                },
-                                Icon {
-                                    class: "open",
-                                    icon: Shape::FolderOpen,
-                                },
-                                "Subfolder 1",
-                            },
-                            input {
-                                id: "tree_folder_control",
-                                "type": "checkbox",
-                            },
-                            label {
-                                class: "tree_folder",
-                                div {
-                                    class: "row",
-                                    Icon {
-                                        class: "closed",
-                                        icon: Shape::Folder,
-                                    },
-                                    Icon {
-                                        class: "open",
-                                        icon: Shape::FolderOpen,
-                                    },
-                                    "Subfolder 2",
-                                },
-                                input {
-                                    id: "tree_folder_control",
-                                    "type": "checkbox",
-                                },
-                                a {
-                                    class: "tree_item",
-                                    div {
-                                        class: "row",
-                                        Icon {
-                                            icon: Shape::Document,
-                                        },
-                                        "Item"
-                                    },
-                                },
-                            }
-                            a {
-                                class: "tree_item",
-                                div {
-                                    class: "row",
-                                    Icon {
-                                        icon: Shape::Document,
-                                    },
-                                    "Item"
-                                },
-                            },
-                        }
-                        a {
-                            class: "tree_item",
-                            div {
-                                class: "row",
-                                Icon {
-                                    icon: Shape::Document,
-                                },
-                                "Item"
-                            },
-                        },
-                    }
-                },
-                label {
-                    class: "tree_folder root",
-                    div {
-                        class: "row",
-                        Icon {
-                            class: "closed",
-                            icon: Shape::Folder,
-                        },
-                        Icon {
-                            class: "open",
-                            icon: Shape::FolderOpen,
-                        },
-                        "Folder 2"
-                    },
-                    input {
-                        id: "tree_folder_control",
-                        "type": "checkbox",
-                    },
-                    a {
-                        class: "tree_item",
-                        div {
-                            class: "row",
-                            Icon {
-                                icon: Shape::Document,
-                            },
-                            "Item"
-                        },
-                    },
-                },
-            }
-        }
-    })
-}
-*/

--- a/src/components/main/files/sidebar/styles.scss
+++ b/src/components/main/files/sidebar/styles.scss
@@ -14,14 +14,7 @@
             cursor: pointer;
             user-select: none;
             margin: 0;
-            .open {
-                display: none;
-            }
 
-            input {
-                position: absolute;
-                visibility: hidden;
-            }
             svg {
                 stroke: var(--theme-text-darker);
             }
@@ -33,22 +26,6 @@
             color: var(--theme-text-darker);
             font-weight: normal;
             font-family: Poppins !important;
-            .tree_folder, .tree_item {
-                display: none;
-                color: var(--theme-text-darker);
-            }
-            &:has(input:checked) {
-                color: var(--theme-text-bright);
-                & .open {
-                    display: inline-flex;
-                }
-                & .open {
-                    display: none;
-                }
-                & > .tree_folder, & > .tree_item {
-                    display: inline-flex;
-                }
-            }
         }
 
         .row {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Implements `Folder` and `FileElem` elements which allow `files/sidebar/mod.rs` to display a directory tree
- the folder icons open/close when clicked
- when a folder is closed, no children are rendered

### Which issue(s) this PR fixes 🔨
- Resolve #136

### Special notes for reviewers 🗒️
- test code is included in `files/sidebar/mod.rs`
- the implementation may need to be tweaked when this is connected to storage. As far as I know, storage could come Warp (IPFS or local cache I guess)
- may need some CSS changes applied from branch 136

### Additional comments 🎤

