### PR TITLE
fix (messaging): don't unwrap when formatting last_msg_time

### DIFF
--- a/src/components/main/sidebar/chat/mod.rs
+++ b/src/components/main/sidebar/chat/mod.rs
@@ -36,7 +36,7 @@ pub fn Chat<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let last_msg_time = cx.props.last_msg_sent.clone().map(|x| {
         let ht = HumanTime::from(x.time);
         let s = ht.to_string();
-        let mut split = s.split(char::is_whitespace).take(2);
+        let mut split = s.split(char::is_whitespace);
         let time = split.next().unwrap_or("");
         let units = split.next().unwrap_or("").chars().next().unwrap_or(' ');
         // TODO: this might not be ideal to support multiple locales.

--- a/src/components/main/sidebar/chat/mod.rs
+++ b/src/components/main/sidebar/chat/mod.rs
@@ -36,12 +36,11 @@ pub fn Chat<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let last_msg_time = cx.props.last_msg_sent.clone().map(|x| {
         let ht = HumanTime::from(x.time);
         let s = ht.to_string();
-        let split: Vec<&str> = s.split(char::is_whitespace).collect();
-        let amount = split.first().unwrap();
-        let c = split.get(1).unwrap();
+        let mut split = s.split(char::is_whitespace).take(2);
+        let time = split.next().unwrap_or("");
+        let units = split.next().unwrap_or("").chars().next().unwrap_or(' ');
         // TODO: this might not be ideal to support multiple locales.
-        let formatted = format!("{}{}", amount, c.chars().next().unwrap());
-        formatted
+        format!("{}{}", time, units)
     });
     let last_msg_sent = cx.props.last_msg_sent.clone().map(|x| x.value);
 


### PR DESCRIPTION
this change hopes to fix the bug where Uplink crashes when sending a message

<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- fixes the Chat element. the timestamp caused a panic. this change uses iterator and unwrap_or("") instead of unwrapping and panicking 

### Which issue(s) this PR fixes 🔨
- Resolve #160

### Special notes for reviewers 🗒️


### Additional comments 🎤

