### PR TITLE
Feat/notifications

### DIFF
--- a/src/components/main/sidebar/mod.rs
+++ b/src/components/main/sidebar/mod.rs
@@ -2,7 +2,7 @@ use dioxus::prelude::*;
 use dioxus_heroicons::outline::Shape;
 use futures::StreamExt;
 use uuid::Uuid;
-use warp::raygun::Message;
+use warp::{multipass::identity::Identity, raygun::Message};
 
 use crate::{
     components::{
@@ -34,6 +34,7 @@ pub struct Props {
 #[allow(non_snake_case)]
 pub fn Sidebar(cx: Scope<Props>) -> Element {
     let config = Config::load_config_or_default();
+    let mp = cx.props.account.clone();
 
     let state = use_atom_ref(&cx, STATE);
     let show_friends = use_state(&cx, || false);
@@ -57,7 +58,17 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
 
     let notifications_tx = use_coroutine(&cx, |mut rx: UnboundedReceiver<Message>| async move {
         while let Some(msg) = rx.next().await {
-            Notifications::push(format!("{}", msg.id()), "content".into());
+            // todo: put display_user and display_username into a common library
+            let display_user = mp
+                .read()
+                .get_identity(msg.sender().clone().into())
+                .unwrap_or_default();
+
+            let display_username = display_user
+                .first()
+                .map(Identity::username)
+                .unwrap_or_else(String::new);
+            Notifications::push(display_username, msg.value().join("\n"));
         }
     });
 

--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -1,11 +1,10 @@
 use notify_rust::Notification;
 
-
 pub struct Notifications {}
 
 // Implementation to create and push new notifications
 impl Notifications {
-    fn push(title: String, content: String) {
+    pub fn push(title: String, content: String) {
         let summary = format!("Uplink - {}", title);
         let _n = Notification::new()
             .summary(summary.as_ref())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- this PR displays a notification when a message is received for a non-active chat

### Which issue(s) this PR fixes 🔨
- Resolve #165

### Special notes for reviewers 🗒️


### Additional comments 🎤
I am assuming that the `CoroutineHandle`, created by the `use_coroutine` function from Dioxus, can be used like one of Tokio's multi-producer single consumer channel - that is - that the handle can be cloned and passed to multiple threads and used in parallel/concurrently with no problem. 
