### PR TITLE
fix (sidebar): order chats by activity

### DIFF
--- a/src/components/main/sidebar/mod.rs
+++ b/src/components/main/sidebar/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         },
     },
     extensions::*,
-    state::Actions,
+    state::{Actions, ConversationInfo},
     utils::{self, config::Config, notifications::PushNotification},
     Account, Messaging, LANGUAGE, STATE,
 };
@@ -64,6 +64,16 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
         }
     });
 
+    // sort the chats by time (ascending order)
+    let mut chats: Vec<ConversationInfo> = state
+        .read()
+        .all_chats
+        .iter()
+        .map(|(_k, v)| v)
+        .cloned()
+        .collect();
+    chats.sort();
+
     cx.render(rsx!{
         div {
             exts,
@@ -100,7 +110,9 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                         },
                         div {
                             class: "chats",
-                            state.read().all_chats.iter().map(|(key, conv)| {
+                            // order the chats with most recent first (descending order)
+                            chats.iter().rev().map(|conv| {
+                                let key = conv.conversation.id();
                                 let conversation_info = conv.clone();
                                 let active_chat = active_chat.clone();
                                 rsx!(


### PR DESCRIPTION
This commit orders chats by most recent activity

<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- This PR orders the chats sidebar. It used to be ordered until I changed the state to a `HashMap`. This change implements `Ord` for `ConversationInfo` so I can read `State.all_chats` into a vector and call `Vector::sort`

### Which issue(s) this PR fixes 🔨
- Resolve #151

### Special notes for reviewers 🗒️


### Additional comments 🎤

