### PR TITLE
fix(profile): move edit profile into settings

### DIFF
--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -77,8 +77,8 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         div {
                             class: "background",
                             div {
-                                class: "profile-photo",
                                 img {
+                                    class: "profile-photo",
                                     src: "{profile_picture}",
                                     height: "100",
                                     width: "100",

--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
-    components::ui_kit::{badge::Badge, profile_picture::PFP, button::Button, icon_input::IconInput, popup::Popup, photo_picker::PhotoPicker},
+    components::ui_kit::{badge::Badge, button::Button, popup::Popup, },
     Account, LANGUAGE, utils,
 };
-use dioxus::{events::FormEvent, prelude::*};
+use dioxus::{prelude::*};
 use dioxus_heroicons::outline::Shape;
 use warp::multipass::identity::Identity;
 
@@ -47,23 +47,8 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             }
         },
     );
-
-    let edit = use_state(&cx, || false);
     let status = my_identity.status_message().unwrap_or_default();
     let profile_picture = utils::get_pfp_from_did(my_identity.did_key(), &cx.props.account.clone());
-
-    // let set_status = move |_: _| {
-    //     let mp = mp.clone();
-    //     if !disabled {
-    //         edit.set(false);
-    //         //TODO: Change to using `MultiPass::update_identity`
-    //         let mut my_identity = match mp.write().get_own_identity() {
-    //             Ok(me) => me,
-    //             Err(_) => Identity::default(),
-    //         };
-    //         my_identity.set_status_message(Some(status.to_string()));
-    //     }
-    // };
 
     cx.render(rsx! {
         Popup {
@@ -92,7 +77,7 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             }, 
                             p {
                                 class: "status",
-                                "{status}"
+                                "{status}, here is status"
                             },
                             Button {
                                 text: l.edit_profile.to_string(),

--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     components::ui_kit::{badge::Badge, button::Button, icon_input::IconInput, popup::Popup, photo_picker::PhotoPicker},
     Account, LANGUAGE,
 };
-use dioxus::{events::FormEvent, prelude::*};
+use dioxus::{prelude::*};
 use dioxus_heroicons::outline::Shape;
 use warp::multipass::identity::Identity;
 
@@ -52,18 +52,18 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let status = use_state(&cx, String::new);
     let disabled = status.is_empty();
 
-    let set_status = move |_: _| {
-        let mp = mp.clone();
-        if !disabled {
-            edit.set(false);
-            //TODO: Change to using `MultiPass::update_identity`
-            let mut my_identity = match mp.write().get_own_identity() {
-                Ok(me) => me,
-                Err(_) => Identity::default(),
-            };
-            my_identity.set_status_message(Some(status.to_string()));
-        }
-    };
+    // let set_status = move |_: _| {
+    //     let mp = mp.clone();
+    //     if !disabled {
+    //         edit.set(false);
+    //         //TODO: Change to using `MultiPass::update_identity`
+    //         let mut my_identity = match mp.write().get_own_identity() {
+    //             Ok(me) => me,
+    //             Err(_) => Identity::default(),
+    //         };
+    //         my_identity.set_status_message(Some(status.to_string()));
+    //     }
+    // };
 
     cx.render(rsx! {
         Popup {
@@ -73,61 +73,47 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 rsx!(
                     div {
                         class: "profile",
-                        div {
-                            class: "background",
-                            div {
-                                PhotoPicker {
-                                    account: cx.props.account.clone(),
-                                },
-                            }
-                        },
+                        // div {
+                        //     class: "background",
+                        //     div {
+                        //         PhotoPicker {
+                        //             account: cx.props.account.clone(),
+                        //         },
+                        //     }
+                        // },
                         div {
                             class: "profile-body",
                             h3 {
                                 class: "username",
                                 "{username}"
                             },
-                            if **edit {rsx! (
-                                div {
-                                    class: "change-status",
-                                    IconInput {
-                                        icon: Shape::PencilAlt,
-                                        placeholder: l.status_placeholder.to_string(),
-                                        value: status.to_string(),
-                                        on_change: move |e: FormEvent| status.set(e.value.clone()),
-                                        on_enter: set_status
-                                    }
-                                },
-                                if disabled {rsx!(
-                                    Button {
-                                        text: l.save_status.to_string(),
-                                        icon: Shape::Check,
-                                        disabled: true,
-                                        on_pressed: move |_| {},
-                                    },
-                                )} else {rsx!(
-                                    Button {
-                                        text: l.save_status.to_string(),
-                                        icon: Shape::Check,
-                                        on_pressed: move |_| {
-                                            // TODO: Pending Voice & Video
-                                            // set_status.call()
-                                        }
-                                    },
-                                )}
-                            )} else {rsx! (
-                                p {
-                                    class: "status",
-                                    "{status}"
-                                },
+                            {rsx! (
+
                                 Button {
                                     text: l.edit_profile.to_string(),
                                     icon: Shape::PencilAlt,
-                                    on_pressed: move |_| {
-                                        edit.set(true);
-                                    },
+                                on_pressed: move |_| {
+                                    use_router(&cx).push_route("/main/settings", None, None);
                                 },
-                            )}
+                                },
+                                // if disabled {rsx!(
+                                //     Button {
+                                //         text: l.save_status.to_string(),
+                                //         icon: Shape::Check,
+                                //         disabled: true,
+                                //         on_pressed: move |_| {},
+                                //     },
+                                // )} else {rsx!(
+                                //     Button {
+                                //         text: l.save_status.to_string(),
+                                //         icon: Shape::Check,
+                                //         on_pressed: move |_| {
+                                //             // TODO: Pending Voice & Video
+                                //             // set_status.call()
+                                //         }
+                                //     },
+                                // )}
+                            )}, 
                             div {
                                 class: "meta",
                                 div {

--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -1,8 +1,8 @@
 use crate::{
-    components::ui_kit::{badge::Badge, button::Button, icon_input::IconInput, popup::Popup, photo_picker::PhotoPicker},
-    Account, LANGUAGE,
+    components::ui_kit::{badge::Badge, profile_picture::PFP, button::Button, icon_input::IconInput, popup::Popup, photo_picker::PhotoPicker},
+    Account, LANGUAGE, utils,
 };
-use dioxus::{prelude::*};
+use dioxus::{events::FormEvent, prelude::*};
 use dioxus_heroicons::outline::Shape;
 use warp::multipass::identity::Identity;
 
@@ -51,6 +51,7 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let edit = use_state(&cx, || false);
     let status = use_state(&cx, String::new);
     let disabled = status.is_empty();
+    let profile_picture = utils::get_pfp_from_did(my_identity.did_key(), &cx.props.account.clone());
 
     // let set_status = move |_: _| {
     //     let mp = mp.clone();
@@ -73,47 +74,35 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 rsx!(
                     div {
                         class: "profile",
-                        // div {
-                        //     class: "background",
-                        //     div {
-                        //         PhotoPicker {
-                        //             account: cx.props.account.clone(),
-                        //         },
-                        //     }
-                        // },
+                        div {
+                            class: "background",
+                            div {
+                                class: "profile-photo",
+                                img {
+                                    src: "{profile_picture}",
+                                    height: "100",
+                                    width: "100",
+                                },
+                            }
+                        },
                         div {
                             class: "profile-body",
                             h3 {
                                 class: "username",
                                 "{username}"
-                            },
-                            {rsx! (
-
+                            }, {rsx! (
+                                p {
+                                    class: "status",
+                                    "{status}"
+                                },
                                 Button {
                                     text: l.edit_profile.to_string(),
                                     icon: Shape::PencilAlt,
-                                on_pressed: move |_| {
-                                    use_router(&cx).push_route("/main/settings", None, None);
+                                    on_pressed: move |_| {
+                                        use_router(&cx).push_route("/main/settings", None, None);
+                                    },
                                 },
-                                },
-                                // if disabled {rsx!(
-                                //     Button {
-                                //         text: l.save_status.to_string(),
-                                //         icon: Shape::Check,
-                                //         disabled: true,
-                                //         on_pressed: move |_| {},
-                                //     },
-                                // )} else {rsx!(
-                                //     Button {
-                                //         text: l.save_status.to_string(),
-                                //         icon: Shape::Check,
-                                //         on_pressed: move |_| {
-                                //             // TODO: Pending Voice & Video
-                                //             // set_status.call()
-                                //         }
-                                //     },
-                                // )}
-                            )}, 
+                            )}
                             div {
                                 class: "meta",
                                 div {

--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -49,8 +49,7 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     );
 
     let edit = use_state(&cx, || false);
-    let status = use_state(&cx, String::new);
-    let disabled = status.is_empty();
+    let status = my_identity.status_message().unwrap_or_default();
     let profile_picture = utils::get_pfp_from_did(my_identity.did_key(), &cx.props.account.clone());
 
     // let set_status = move |_: _| {
@@ -90,19 +89,18 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             h3 {
                                 class: "username",
                                 "{username}"
-                            }, {rsx! (
-                                p {
-                                    class: "status",
-                                    "{status}"
+                            }, 
+                            p {
+                                class: "status",
+                                "{status}"
+                            },
+                            Button {
+                                text: l.edit_profile.to_string(),
+                                icon: Shape::PencilAlt,
+                                on_pressed: move |_| {
+                                    use_router(&cx).push_route("/main/settings", None, None);
                                 },
-                                Button {
-                                    text: l.edit_profile.to_string(),
-                                    icon: Shape::PencilAlt,
-                                    on_pressed: move |_| {
-                                        use_router(&cx).push_route("/main/settings", None, None);
-                                    },
-                                },
-                            )}
+                            },
                             div {
                                 class: "meta",
                                 div {

--- a/src/components/main/settings/pages/profile/mod.rs
+++ b/src/components/main/settings/pages/profile/mod.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 
 use crate::{
-    components::ui_kit::{ badge::Badge, button::Button, icon_input::IconInput, popup::Popup, photo_picker::PhotoPicker },
+    components::ui_kit::{ button::Button, icon_input::IconInput, photo_picker::PhotoPicker },
     Account, LANGUAGE
 };
 use dioxus_heroicons::outline::Shape;
@@ -31,9 +31,20 @@ pub fn Profile(cx: Scope<Props>) -> Element {
             };
             my_identity.set_status_message(Some(status.to_string()));
     };
+
+    // let status = my_identity.status_message().unwrap_or_default();
     cx.render(rsx! {
         div {
             id: "page_profile",
+            div {
+                class: "profile_header",
+                div {
+                    class: "profile_picture",
+                    PhotoPicker {
+                        account: cx.props.account.clone(),
+                    },
+                }
+            },
             div {
                 class: "",
                 div {
@@ -48,7 +59,7 @@ pub fn Profile(cx: Scope<Props>) -> Element {
                     class: "row input_status",
                     IconInput {
                         icon: Shape::PencilAlt,
-                        placeholder: l.status_placeholder.to_string(),
+                        placeholder: status.to_string(),
                         value: status.to_string(),
                         on_change: move |e: FormEvent| status.set(e.value.clone()),
                         on_enter: set_status
@@ -65,22 +76,6 @@ pub fn Profile(cx: Scope<Props>) -> Element {
 
             }
             },
-            div {
-                class: "item",
-                div {
-                    class: "profile_picture",
-                    div {
-                        label {
-                            "Choose a profile picture."
-                        }
-                        div {
-                            PhotoPicker {
-                                account: cx.props.account.clone(),
-                            },
-                        }
-                    },
-                },
-            }
         }
     })
 }

--- a/src/components/main/settings/pages/profile/mod.rs
+++ b/src/components/main/settings/pages/profile/mod.rs
@@ -1,6 +1,12 @@
 use dioxus::prelude::*;
 
-use crate::Account;
+use crate::{
+    components::ui_kit::{ badge::Badge, button::Button, icon_input::IconInput, popup::Popup, photo_picker::PhotoPicker },
+    Account, LANGUAGE
+};
+use dioxus_heroicons::outline::Shape;
+use dioxus::{events::FormEvent};
+use warp::multipass::identity::Identity;
 
 #[derive(Props, PartialEq)]
 pub struct Props {
@@ -9,24 +15,70 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Profile(cx: Scope<Props>) -> Element {
+
+    let l = use_atom_ref(&cx, LANGUAGE).read();
+    let edit = use_state(&cx, || false);
+    let status = use_state(&cx, String::new);
+    let mp = cx.props.account.clone();
+    let set_status = move |_: _| {
+        let mp = mp.clone();
+            edit.set(false);
+            //TODO: Change to using `MultiPass::update_identity`
+            let mut my_identity = match mp.write().get_own_identity() {
+                Ok(me) => me,
+                Err(_) => Identity::default(),
+            };
+            my_identity.set_status_message(Some(status.to_string()));
+    };
     cx.render(rsx! {
         div {
             id: "page_profile",
             div {
-                class: "item",
+                class: "",
                 div {
-                    class: "description",
+                    class: "status",
                     label {
                         "Status Message"
                     },
-                    p {
-                        "Set a custom status message and let people know what's happening."
-                    }
                 },
                 div {
-                    class: "interactive",
-                    "input here"
+                    class: "row change-status",
+                div {
+                    class: "row input_status",
+                    IconInput {
+                        icon: Shape::PencilAlt,
+                        placeholder: l.status_placeholder.to_string(),
+                        value: status.to_string(),
+                        on_change: move |e: FormEvent| status.set(e.value.clone()),
+                        on_enter: set_status
+                    },
+                },
+                div {
+                    class: "",
+                    Button {
+                        text: l.save_status.to_string(),
+                        icon: Shape::Check,
+                        on_pressed: move |_| {},
+                    }
                 }
+
+            }
+            },
+            div {
+                class: "item",
+                div {
+                    class: "profile_picture",
+                    div {
+                        label {
+                            "Choose a profile picture."
+                        }
+                        div {
+                            PhotoPicker {
+                                account: cx.props.account.clone(),
+                            },
+                        }
+                    },
+                },
             }
         }
     })

--- a/src/components/main/settings/pages/profile/mod.rs
+++ b/src/components/main/settings/pages/profile/mod.rs
@@ -13,6 +13,7 @@ pub struct Props {
     account: Account,
 }
 
+
 #[allow(non_snake_case)]
 pub fn Profile(cx: Scope<Props>) -> Element {
 

--- a/src/components/main/settings/pages/profile/mod.rs
+++ b/src/components/main/settings/pages/profile/mod.rs
@@ -32,7 +32,6 @@ pub fn Profile(cx: Scope<Props>) -> Element {
             my_identity.set_status_message(Some(status.to_string()));
     };
 
-    // let status = my_identity.status_message().unwrap_or_default();
     cx.render(rsx! {
         div {
             id: "page_profile",
@@ -46,7 +45,6 @@ pub fn Profile(cx: Scope<Props>) -> Element {
                 }
             },
             div {
-                class: "",
                 div {
                     class: "status",
                     label {
@@ -54,9 +52,9 @@ pub fn Profile(cx: Scope<Props>) -> Element {
                     },
                 },
                 div {
-                    class: "row change-status",
+                    class: "change-status",
                 div {
-                    class: "row input_status",
+                    class: "input_status",
                     IconInput {
                         icon: Shape::PencilAlt,
                         placeholder: status.to_string(),
@@ -66,7 +64,6 @@ pub fn Profile(cx: Scope<Props>) -> Element {
                     },
                 },
                 div {
-                    class: "",
                     Button {
                         text: l.save_status.to_string(),
                         icon: Shape::Check,

--- a/src/components/main/settings/pages/profile/styles.scss
+++ b/src/components/main/settings/pages/profile/styles.scss
@@ -1,7 +1,3 @@
-.status {
-    // flex: auto;
-}
-
 .input_status {
     width: 60%;
 }

--- a/src/components/main/settings/pages/profile/styles.scss
+++ b/src/components/main/settings/pages/profile/styles.scss
@@ -1,0 +1,11 @@
+.status {
+    // flex: auto;
+}
+
+.input_status {
+    width: 60%;
+}
+.change-status {
+    display: flex;
+    justify-content: space-between;
+}

--- a/src/components/main/settings/pages/profile/styles.scss
+++ b/src/components/main/settings/pages/profile/styles.scss
@@ -5,3 +5,20 @@
     display: flex;
     justify-content: space-between;
 }
+
+.profile_header {
+    background: var(--theme-text-muted);
+    border-radius: 8px 8px 0 0;
+    height: 140px;
+    margin-bottom: 40px;
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    justify-items: center;
+
+}
+
+.profile_picture {
+    margin-top: 80px;
+}

--- a/src/components/ui_kit/photo_picker/mod.rs
+++ b/src/components/ui_kit/photo_picker/mod.rs
@@ -25,7 +25,6 @@ pub fn PhotoPicker(cx: Scope<Props>) -> Element {
         div {
             class: "photo-picker",
             div {
-                class: "display",
                 if show_profile_picture {
                     rsx! {
                         Icon {
@@ -36,6 +35,7 @@ pub fn PhotoPicker(cx: Scope<Props>) -> Element {
                 } else {
                     rsx!{
                         img {
+                            class: "profile_photo",
                             src: "{image_state}",
                             height: "100",
                             width: "100",

--- a/src/components/ui_kit/photo_picker/styles.scss
+++ b/src/components/ui_kit/photo_picker/styles.scss
@@ -7,6 +7,15 @@
     border-radius: 50px;
     display: inline-block;
     position: relative;
+    justify-content: center;
+}
+
+.profile_photo {
+            border: 2px solid var(--theme-foreground);
+            border-radius: 100px;
+            height: 100px;
+            width: 100px;
+
 }
 
 .photo-picker .display {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use warp_rg_ipfs::config::RgIpfsConfig;
 use warp_rg_ipfs::Persistent;
 
 use crate::components::main;
+use crate::components::main::settings::sidebar::nav::NavEvent;
 use crate::components::prelude::{auth, loading, unlock};
 
 pub mod components;


### PR DESCRIPTION


### What this PR does 📖
routes edit profile button in sidebar to go to settings, move edit profile into settings

### Which issue(s) this PR fixes 🔨
- Resolve #
#164 

### Special notes for reviewers 🗒️

new tickets:
1. Updating status message is broken and needs its own ticket.
2. Need to get edit profile button to go directly to profile tab.

