### PR TITLE
fix(profile-settings): center profile picture placeholder icon

### DIFF
--- a/src/components/ui_kit/photo_picker/mod.rs
+++ b/src/components/ui_kit/photo_picker/mod.rs
@@ -21,9 +21,8 @@ pub fn PhotoPicker(cx: Scope<Props>) -> Element {
     let show_profile_picture = base64_picture.is_empty();
 
     cx.render(rsx! {
-        div {
-            class: "photo-picker",
             div {
+                class: "photo-picker",
                 if show_profile_picture {
                     rsx! {
                         Icon {
@@ -41,7 +40,6 @@ pub fn PhotoPicker(cx: Scope<Props>) -> Element {
                         }
                     }
                 }
-            }
             IconButton {
                 icon: Shape::Plus,
                 on_pressed: move |_| {

--- a/src/components/ui_kit/photo_picker/styles.scss
+++ b/src/components/ui_kit/photo_picker/styles.scss
@@ -5,9 +5,10 @@
   height: 100px;
   background: var(--theme-secondary);
   border-radius: 50px;
-  display: inline-block;
+  display: flex;
   position: relative;
   justify-content: center;
+  align-items: center;
 }
 
 .profile_photo {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Centers the profile picture placeholder icon in Settings -> Profile 

Before:
<img width="456" alt="Screen Shot 2022-11-04 at 10 06 52 AM" src="https://user-images.githubusercontent.com/93608357/199995207-fc9f850a-bbcc-4bb8-8ec1-5935ade7dd6f.png">

After:
<img width="1062" alt="スクリーンショット 2022-11-07 12 35 22" src="https://user-images.githubusercontent.com/40599535/200208987-eea7f73a-2d64-4b6b-a736-b831939607c6.png">

### Which issue(s) this PR fixes 🔨
- Resolve #201 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->