### PR TITLE
fix(unlock): align login action buttons

### DIFF
--- a/src/components/prelude/unlock/styles.scss
+++ b/src/components/prelude/unlock/styles.scss
@@ -43,8 +43,7 @@
 
   .login-actions {
     bottom: 2rem;
-    display: inline-block;
-    left: 2rem;
+    display: flex;
     max-height: 40px;
     position: fixed;
     right: 2rem;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
Before:
<img width="1033" alt="スクリーンショット 2022-11-07 10 04 13" src="https://user-images.githubusercontent.com/40599535/200200160-2e2c4316-22ae-40b3-8e2e-dd56c317d525.png">

After:
<img width="1062" alt="スクリーンショット 2022-11-07 12 51 54" src="https://user-images.githubusercontent.com/40599535/200210600-2fc97974-174c-4cd5-9ae0-e4ba3d12a496.png">


### Which issue(s) this PR fixes 🔨
- Resolve #208 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->