### PR TITLE
Fix duplicate profile photo class

### DIFF
--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -73,10 +73,9 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                         } else {
                                             rsx!(
                                             img {
-                                                class: "profile-photo",
                                                 src: "{profile_picture}",
-                                                height: "100",
-                                                width: "100",
+                                                height: "100%",
+                                                width: "100%",
                                             })
                                     }
                                 }

--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -60,26 +60,29 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             class: "profile",
                             div {
                                 class: "background",
-                                rsx! (
+                            if profile_picture != "" {
+                                rsx!(
+                                    img {
+                                        class: "profile-photo",
+                                        src: "{profile_picture}",
+                                        height: "100",
+                                        width: "100",
+                                    }
+                                )
+                            } else {
+                                rsx!(
                                     div {
                                         class: "profile-photo",
-                                        if profile_picture == "" {
-                                            rsx! {
+                                         rsx! {
                                                 Icon {
                                                     size: 40,
                                                     icon: Shape::User,
                                                 },
                                             }
-                                        } else {
-                                            rsx!(
-                                            img {
-                                                src: "{profile_picture}",
-                                                height: "100%",
-                                                width: "100%",
-                                            })
+                                  
                                     }
-                                }
-    )
+                                )
+                            }                            
                             },
                             div {
                                 class: "profile-body",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

### 1. There was a duplicated class "profile-photo" when we upload a new picture 
![image](https://user-images.githubusercontent.com/63157656/200644995-e552af13-7dd1-42ae-8c2f-b30a8547482a.png)

![image](https://user-images.githubusercontent.com/63157656/200644482-9e6597ac-f3b9-487f-84a4-d9d077ea0caa.png)

### 2. Change the order of logic to just use this class one time when upload a picture, or as before has no picture
![image](https://user-images.githubusercontent.com/63157656/200645208-d7b756ab-4545-4c7f-9c9c-7c88fd7d37f7.png)
![image](https://user-images.githubusercontent.com/63157656/200645508-c280a544-8b33-4cd1-b9ae-2ba71804febb.png)


### Which issue(s) this PR fixes 🔨
- Resolve #254 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

