### PR TITLE
Update: Fix navigation to profile and general menu on settings sidebar

### DIFF
--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -98,7 +98,7 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                     text: l.edit_profile.to_string(),
                                     icon: Shape::PencilAlt,
                                     on_pressed: move |_| {
-                                        use_router(&cx).push_route("/main/settings", None, None);
+                                        use_router(&cx).push_route("/main/settings/profile", None, None);
                                     },
                                 },
                                 div {

--- a/src/components/main/settings/mod.rs
+++ b/src/components/main/settings/mod.rs
@@ -17,11 +17,18 @@ pub mod sidebar;
 #[derive(Props, PartialEq)]
 pub struct Props {
     account: Account,
+    page_to_open: NavEvent,
 }
 
 #[allow(non_snake_case)]
 pub fn Settings(cx: Scope<Props>) -> Element {
-    let active_page = use_state(&cx, || NavEvent::Developer);
+    let page_to_open_on_settings =  match cx.props.page_to_open {
+        NavEvent::Profile => NavEvent::Profile, 
+        NavEvent::Developer => NavEvent::Developer, 
+        _ => NavEvent::General,
+    };
+ 
+    let active_page = use_state(&cx, || page_to_open_on_settings);
 
     cx.render(rsx! {
         div {
@@ -29,6 +36,11 @@ pub fn Settings(cx: Scope<Props>) -> Element {
             sidebar::SettingsSidebar {
                 on_pressed: move |ne| {
                     active_page.set(ne);
+                },
+                initial_value: match active_page.get() {
+                    NavEvent::Profile => NavEvent::Profile, 
+                    NavEvent::Developer => NavEvent::Developer, 
+                    _ => NavEvent::General,
                 },
             },
             div {

--- a/src/components/main/settings/sidebar/mod.rs
+++ b/src/components/main/settings/sidebar/mod.rs
@@ -16,10 +16,16 @@ pub mod nav;
 #[derive(Props)]
 pub struct Props<'a> {
     on_pressed: EventHandler<'a, NavEvent>,
+    initial_value: NavEvent,
 }
 
 #[allow(non_snake_case)]
 pub fn SettingsSidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    let initial_value =  match cx.props.initial_value {
+        NavEvent::Profile => NavEvent::Profile, 
+        NavEvent::Developer => NavEvent::Developer, 
+        _ => NavEvent::General,
+    };
     let config = Config::load_config_or_default();
 
     cx.render(rsx! {
@@ -39,6 +45,7 @@ pub fn SettingsSidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 on_pressed: move |ne| {
                     cx.props.on_pressed.call(ne);
                 }
+                initial_value: initial_value,
             },
             config.developer.developer_mode.then(|| rsx! {
                 ExtensionPlaceholder {},

--- a/src/components/main/settings/sidebar/nav/mod.rs
+++ b/src/components/main/settings/sidebar/nav/mod.rs
@@ -43,11 +43,17 @@ pub fn NavButton<'a>(cx: Scope<'a, ButtonProps<'a>>) -> Element<'a> {
 #[derive(Props)]
 pub struct Props<'a> {
     on_pressed: EventHandler<'a, NavEvent>,
+    initial_value: NavEvent,
 }
 
 #[allow(non_snake_case)]
 pub fn Nav<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let active_item = use_state(&cx, || NavEvent::Developer);
+    let initial_value =  match cx.props.initial_value {
+        NavEvent::Profile => NavEvent::Profile, 
+        NavEvent::Developer => NavEvent::Developer, 
+        _ => NavEvent::General,
+    };
+    let active_item = use_state(&cx, || initial_value);
 
     cx.render(rsx! {
         div {

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,9 +221,16 @@ fn App(cx: Scope<State>) -> Element {
             Route { to: "/auth", auth::Auth { account: cx.props.account.clone() } },
             Route { to: "/main/files", main::files::Files { account: cx.props.account.clone() } },
             Route { to: "/main/settings", main::settings::Settings {
-                    account: cx.props.account.clone(),
-                },
+                account: cx.props.account.clone(), 
+                page_to_open: main::settings::sidebar::nav::NavEvent::General,
+            }
             },
+            Route { to: "/main/settings/profile", main::settings::Settings {
+                account: cx.props.account.clone(), 
+                page_to_open: main::settings::sidebar::nav::NavEvent::Profile,
+            }
+            },
+     
             Route { to: "/main", main::Main { account: cx.props.account.clone(), messaging: cx.props.messaging.clone() } },
         }
     ))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

### 1. Click on Edit Profile now or in the gear of the bottom nav bar, it goes to respective places on Settings
a. The normal route now is to General and not developer tab bar 
![image](https://user-images.githubusercontent.com/63157656/200666110-e953f1c8-7a3f-4773-a792-f104874202f2.png)
b. Click on Edit Profile goes to Profile tab bar on settings 
![image](https://user-images.githubusercontent.com/63157656/200666971-329742b2-da24-452d-92b2-ef4caa355992.png)
c. For now, just did for three available menus, Profile, Developer and General
![image](https://user-images.githubusercontent.com/63157656/200669636-4d5ac7b4-e90f-4d04-afbd-4b7af042eeab.png)


### 2. Going to general and Profile tab bar menu 

https://user-images.githubusercontent.com/63157656/200667592-26322cdc-c43d-4479-9b9f-07d5b82c9539.mov




### Which issue(s) this PR fixes 🔨
- Resolve #252 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

