### PR TITLE
Fix/message times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ clap = { version = "3.2", features = ["derive"] }
 toml = "0.5.9"
 tokio = { version = "1", features = ["full"] }
 chrono = "0.4.22"
-chrono-humanize = "0.2.2"
 futures = "0.3"
 dirs = "4.0.0"
 rodio = "0.16.0"

--- a/src/components/main/compose/messages/mod.rs
+++ b/src/components/main/compose/messages/mod.rs
@@ -43,11 +43,8 @@ pub fn Messages(cx: Scope<Props>) -> Element {
         true
     });
 
-    match should_reload.value() {
-        Some(_) => {
-            cx.needs_update();
-        }
-        None => {}
+    if let Some(_) = should_reload.value() {
+        cx.needs_update();
     };
 
     // restart the use_future when the current_chat changes

--- a/src/components/main/compose/msg/mod.rs
+++ b/src/components/main/compose/msg/mod.rs
@@ -1,4 +1,3 @@
-use chrono_humanize::HumanTime;
 use dioxus::prelude::*;
 use dioxus_heroicons::outline::Shape;
 use embeds::LinkEmbed;
@@ -72,7 +71,7 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
     let value = cx.props.message.clone().value().join("\n");
 
     let timestamp = cx.props.message.clone().date();
-    let ht = HumanTime::from(timestamp);
+    let ht = utils::display_msg_time(timestamp);
     let remote = match cx.props.remote {
         true => "remote",
         false => "local",

--- a/src/components/main/mod.rs
+++ b/src/components/main/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     state::{Actions, ConversationInfo},
     Account, Messaging, STATE,
 };
+use chrono::prelude::*;
 use dioxus::prelude::*;
 use std::{collections::HashMap, time::Duration};
 use uuid::Uuid;
@@ -55,6 +56,7 @@ pub fn Main(cx: Scope<Prop>) -> Element {
                     for item in new_chats {
                         let ci = ConversationInfo {
                             conversation: item.clone(),
+                            creation_time: DateTime::from(Local::now()),
                             ..Default::default()
                         };
                         new_map.insert(item.id(), ci);

--- a/src/components/main/sidebar/chat/mod.rs
+++ b/src/components/main/sidebar/chat/mod.rs
@@ -38,7 +38,11 @@ pub fn Chat<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     let online_status = use_state(&cx, || IdentityStatus::Offline).clone();
     let online_status2 = online_status.clone();
 
-    let last_msg_time = cx.props.last_msg_sent.clone().map(|x| x.display_time());
+    let last_msg_time = cx
+        .props
+        .last_msg_sent
+        .clone()
+        .map(|x| utils::display_msg_time(x.time));
     let last_msg_sent = cx.props.last_msg_sent.clone().map(|x| x.value);
     let tx_chan = cx.props.tx_chan.clone();
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,5 +1,4 @@
 use chrono::prelude::*;
-use chrono_humanize::HumanTime;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::{Ord, Ordering},
@@ -32,7 +31,7 @@ pub struct PersistedState {
 #[derive(Serialize, Deserialize, Default, Clone, Eq, PartialEq)]
 pub struct LastMsgSent {
     pub value: String,
-    pub time: DateTime<Local>,
+    pub time: DateTime<Utc>,
 }
 
 /// composes `Conversation` with relevant metadata
@@ -45,7 +44,7 @@ pub struct ConversationInfo {
     /// the first two lines of the last message sent
     pub last_msg_sent: Option<LastMsgSent>,
     /// the time the conversation was created. used to sort the chats
-    pub creation_time: DateTime<Local>,
+    pub creation_time: DateTime<Utc>,
 }
 
 impl Ord for ConversationInfo {
@@ -161,17 +160,7 @@ impl LastMsgSent {
                 .chars()
                 .take(24)
                 .collect(),
-            time: Local::now(),
+            time: DateTime::from(Local::now()),
         }
-    }
-
-    pub fn display_time(&self) -> String {
-        let ht = HumanTime::from(self.time);
-        let s = ht.to_string();
-        let mut split = s.split(char::is_whitespace);
-        let time = split.next().unwrap_or("");
-        let units = split.next().unwrap_or("").chars().next().unwrap_or(' ');
-        // TODO: this might not be ideal to support multiple locales.
-        format!("{}{}", time, units)
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,12 +1,13 @@
-use regex::Regex;
-use warp::{crypto::DID, multipass::identity::Identity};
-
-use crate::{state::ConversationInfo, Account};
-
 pub mod config;
 pub mod get_meta;
 pub mod notifications;
 pub mod sounds;
+
+use crate::{state::ConversationInfo, Account};
+
+use chrono::{prelude::*, Duration};
+use regex::Regex;
+use warp::{crypto::DID, multipass::identity::Identity};
 
 pub fn remove_writespace(s: &mut String) {
     s.retain(|c| !c.is_whitespace());
@@ -33,6 +34,37 @@ pub fn get_username_from_did(did: DID, mp: &Account) -> String {
         .first()
         .map(Identity::username)
         .unwrap_or_else(String::new)
+}
+
+// minutes, hours, days up to 7, then the date
+pub fn display_msg_time(timestamp: DateTime<Utc>) -> String {
+    // todo: get language for the text here.
+    let current_time: DateTime<Local> = Local::now();
+    let msg_time: DateTime<Local> = DateTime::from(timestamp);
+    let difference: Duration = current_time - msg_time;
+
+    let days = difference.num_days();
+
+    if days > 7 {
+        format!(
+            "{}/{}/{}",
+            msg_time.month(),
+            msg_time.day(),
+            msg_time.year()
+        )
+    } else if days >= 1 {
+        format!("{}d", days)
+    } else {
+        let minutes = difference.num_minutes();
+        let hours = difference.num_hours();
+        if hours >= 1 {
+            format!("{}h", hours)
+        } else if minutes > 1 {
+            format!("{}m", minutes)
+        } else {
+            "now".to_string()
+        }
+    }
 }
 
 pub fn get_pfp_from_did(did: DID, mp: &Account) -> Option<String> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- This PR fixes a bug involving displaying timestamps and profile pictures associated with messages. 
- It also fixes the timestamp formatting as follows: display the last X minutes or hours or days (up to 7) or the month/day/year
- It also fixes a bug where the timestamp associated with a conversation was being initialized to zero rather than the current time. 
- The `Messages` module is now refreshed every 60 seconds. this will cause the timestamps to update. 

### Which issue(s) this PR fixes 🔨
- Resolve #250
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

