### PR TITLE
Fix send empty message and trim spaces at beginning and end of message

### DIFF
--- a/src/components/ui_kit/textarea/mod.rs
+++ b/src/components/ui_kit/textarea/mod.rs
@@ -51,7 +51,9 @@ pub fn TextArea<'a>(
                 },
                 onkeyup: |e| {
                     if e.data.key_code.eq(&KeyCode::Enter) && !e.data.shift_key {
-                        on_submit.call(text.to_string());
+                        if !text.trim().is_empty() {
+                            on_submit.call(text.trim().to_string());
+                        }
                         text.set(String::from(""));
                         clearing_state.set(true);
                     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Doesn't allow user to send message if it is empty 

### 2. Trim spaces at beginning and end of message 

![image](https://user-images.githubusercontent.com/63157656/201202164-2b0a2620-8397-4b64-8252-94b74ee56ad5.png)



https://user-images.githubusercontent.com/63157656/201202600-6aae9999-4373-4cb2-b7e9-7e808190072b.mov



### Which issue(s) this PR fixes 🔨
- Resolve #255 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

