### PR TITLE
chore(responsive): make sidebar on chat view responsive

### DIFF
--- a/src/components/main/compose/messages/styles.scss
+++ b/src/components/main/compose/messages/styles.scss
@@ -4,7 +4,6 @@
   display: inline-flex;
   flex-direction: column-reverse;
   height: 100%;
-  max-width: calc(100vw - 330px - 2rem);
   min-width: 300px;
   overflow-x: hidden;
   overflow-y: scroll;

--- a/src/components/main/compose/topbar/mod.rs
+++ b/src/components/main/compose/topbar/mod.rs
@@ -8,6 +8,7 @@ use crate::{
             skeletons::{inline::InlineSkeleton, pfp::PFPSkeleton},
         },
     },
+    state::Actions,
     utils::{self, config::Config},
     Account, STATE,
 };
@@ -46,6 +47,16 @@ pub fn TopBar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             cx.render(rsx! {
                 toolbar::Toolbar {
                     controls: cx.render(rsx! {
+                        div {
+                            class: "mobile-back-button",
+                            IconButton {
+                                icon: Shape::ArrowLeft,
+                                state: crate::components::ui_kit::icon_button::State::Secondary,
+                                on_pressed: move |_| {
+                                    state.write().dispatch(Actions::HideSidebar(false));
+                                },
+                            },
+                        },
                         IconButton {
                             icon: Shape::Heart,
                             state: crate::components::ui_kit::icon_button::State::Secondary,

--- a/src/components/main/compose/topbar/mod.rs
+++ b/src/components/main/compose/topbar/mod.rs
@@ -47,16 +47,6 @@ pub fn TopBar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             cx.render(rsx! {
                 toolbar::Toolbar {
                     controls: cx.render(rsx! {
-                        div {
-                            class: "mobile-back-button",
-                            IconButton {
-                                icon: Shape::ArrowLeft,
-                                state: crate::components::ui_kit::icon_button::State::Secondary,
-                                on_pressed: move |_| {
-                                    state.write().dispatch(Actions::HideSidebar(false));
-                                },
-                            },
-                        },
                         IconButton {
                             icon: Shape::Heart,
                             state: crate::components::ui_kit::icon_button::State::Secondary,
@@ -76,6 +66,16 @@ pub fn TopBar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             },
                         }
                     }),
+                    div {
+                        class: "mobile-back-button",
+                        IconButton {
+                            icon: Shape::ArrowLeft,
+                            state: crate::components::ui_kit::icon_button::State::Secondary,
+                            on_pressed: move |_| {
+                                state.write().dispatch(Actions::HideSidebar(false));
+                            },
+                        },
+                    },
                     PFP {
                         src: profile_picture,
                         size: crate::components::ui_kit::profile_picture::Size::Normal

--- a/src/components/main/friends/sidebar/mod.rs
+++ b/src/components/main/friends/sidebar/mod.rs
@@ -262,6 +262,5 @@ pub fn FindFriends(cx: Scope, account: Account, add_error: UseState<String>) -> 
                 }
             }
         },
-    
     ))
 }

--- a/src/components/main/mod.rs
+++ b/src/components/main/mod.rs
@@ -29,7 +29,10 @@ pub fn Main(cx: Scope<Prop>) -> Element {
     let rg = cx.props.messaging.clone();
     let state = use_atom_ref(&cx, STATE);
     let display_welcome = state.read().current_chat.is_none();
-
+    let hide_sidebar = match st.read().hide_sidebar {
+        false => "main-sidebar",
+        true => "main-chat",
+    };
     use_future(&cx, (), |_| async move {
         loop {
             if let Ok(list) = rg.list_conversations().await {
@@ -58,7 +61,7 @@ pub fn Main(cx: Scope<Prop>) -> Element {
 
     cx.render(rsx! {
         div {
-            class: "main",
+            class: "main {hide_sidebar}",
             rsx!(
                 Sidebar {
                     messaging: cx.props.messaging.clone(),

--- a/src/components/main/settings/mod.rs
+++ b/src/components/main/settings/mod.rs
@@ -1,9 +1,7 @@
 use dioxus::prelude::*;
 
 use crate::{
-    components::{
-        main::settings::pages::{developer::Developer, general::General, profile::Profile},
-    },
+    components::main::settings::pages::{developer::Developer, general::General, profile::Profile},
     Account,
 };
 
@@ -20,7 +18,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Settings(cx: Scope<Props>) -> Element {
-    let page_to_open_on_settings =  match cx.props.page_to_open {
+    let page_to_open_on_settings = match cx.props.page_to_open {
         NavEvent::Profile => NavEvent::Profile,
         NavEvent::Developer => NavEvent::Developer,
         _ => NavEvent::General,

--- a/src/components/main/sidebar/mod.rs
+++ b/src/components/main/sidebar/mod.rs
@@ -35,7 +35,6 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
 
     let state = use_atom_ref(&cx, STATE);
     let show_profile = use_state(&cx, || false);
-
     let l = use_atom_ref(&cx, LANGUAGE).read();
     let chatsdString = l.chats.to_string();
     let has_chats = !state.read().all_chats.is_empty();
@@ -110,6 +109,8 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                         is_active: active_chat == Some(conversation_info.conversation.id()),
                                         tx_chan: notifications_tx.clone(),
                                         on_pressed: move |uuid| {
+                                            // on press, change state so CSS class flips to show the chat
+                                            state.write().dispatch(Actions::HideSidebar(true));
                                             if *active_chat != Some(uuid) {
                                                 state.write().dispatch(Actions::ChatWith(conversation_info.clone()));
                                                 active_chat.set(Some(uuid));

--- a/src/components/main/styles.scss
+++ b/src/components/main/styles.scss
@@ -9,3 +9,33 @@
   -webkit-user-select: none;
   user-select: none;
 }
+
+.mobile-back-button {
+  display: none;
+}
+
+@media only screen and (max-width: 600px) {
+  .main-sidebar {
+    .sidebar {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+    }
+    .compose {
+      display: none;
+    }
+  }
+  .main-chat {
+    .sidebar {
+      display: none;
+    }
+    .compose {
+      width: 100%;
+      height: 100%;
+      position: absolute;
+    }
+  }
+  .mobile-back-button {
+    display: block;
+  }
+}

--- a/src/components/main/styles.scss
+++ b/src/components/main/styles.scss
@@ -37,5 +37,6 @@
   }
   .mobile-back-button {
     display: block;
+    margin-right: 5px;
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,14 @@ use sir::AppStyle;
 use state::PersistedState;
 use themes::Theme;
 use utils::config::Config;
-use warp::{multipass::MultiPass, raygun::RayGun, constellation::Constellation, sync::RwLock, tesseract::Tesseract};
-use warp_mp_ipfs::config::MpIpfsConfig;
+use warp::{
+    constellation::Constellation, multipass::MultiPass, raygun::RayGun, sync::RwLock,
+    tesseract::Tesseract,
+};
 use warp_fs_ipfs::config::FsIpfsConfig;
+use warp_mp_ipfs::config::MpIpfsConfig;
 use warp_rg_ipfs::config::RgIpfsConfig;
 use warp_rg_ipfs::Persistent;
-
 
 use crate::components::main;
 use crate::components::prelude::{auth, loading, unlock};
@@ -178,7 +180,6 @@ async fn initialization(
         Arc<RwLock<Box<dyn MultiPass>>>,
         Arc<RwLock<Box<dyn RayGun>>>,
         Arc<RwLock<Box<dyn Constellation>>>,
-
     ),
     warp::error::Error,
 > {
@@ -196,10 +197,12 @@ async fn initialization(
     .await
     .map(|rg| Arc::new(RwLock::new(Box::new(rg) as Box<dyn RayGun>)))?;
 
-    let storage = warp_fs_ipfs::IpfsFileSystem::<warp_fs_ipfs::Persistent>::new(account.clone(),
-        Some(FsIpfsConfig::production(path)))
-        .await
-        .map(|ct| Arc::new(RwLock::new(Box::new(ct) as Box<dyn Constellation>)))?;
+    let storage = warp_fs_ipfs::IpfsFileSystem::<warp_fs_ipfs::Persistent>::new(
+        account.clone(),
+        Some(FsIpfsConfig::production(path)),
+    )
+    .await
+    .map(|ct| Arc::new(RwLock::new(Box::new(ct) as Box<dyn Constellation>)))?;
 
     Ok((account, messenging, storage))
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -14,6 +14,7 @@ pub enum Actions {
     ChatWith(ConversationInfo),
     UpdateConversation(ConversationInfo),
     UpdateFavorites(HashSet<Uuid>),
+    HideSidebar(bool),
 }
 
 /// tracks the active conversations. Chagnes are persisted
@@ -26,6 +27,8 @@ pub struct PersistedState {
     /// a list of favorited conversations.
     /// Uuid is for Conversation and can be used to look things up in all_chats
     pub favorites: HashSet<Uuid>,
+    // show sidebar boolean, used with in mobile view
+    pub hide_sidebar: bool,
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Eq, PartialEq)]
@@ -105,18 +108,21 @@ impl PersistedState {
                     current_chat: self.current_chat,
                     all_chats: new_chats,
                     favorites,
+                    hide_sidebar: self.hide_sidebar,
                 }
             }
             Actions::ChatWith(info) => PersistedState {
                 current_chat: Some(info.conversation.id()),
                 all_chats: self.all_chats.clone(),
                 favorites: self.favorites.clone(),
+                hide_sidebar: self.hide_sidebar,
             },
             Actions::UpdateConversation(info) => {
                 let mut next = PersistedState {
                     current_chat: self.current_chat,
                     all_chats: self.all_chats.clone(),
                     favorites: self.favorites.clone(),
+                    hide_sidebar: self.hide_sidebar,
                 };
                 // overwrite the existing entry
                 next.all_chats.insert(info.conversation.id(), info);
@@ -126,6 +132,13 @@ impl PersistedState {
                 current_chat: self.current_chat,
                 all_chats: self.all_chats.clone(),
                 favorites,
+                hide_sidebar: self.hide_sidebar,
+            },
+            Actions::HideSidebar(slide_bar_bool) => PersistedState {
+                current_chat: self.current_chat,
+                all_chats: self.all_chats.clone(),
+                favorites: self.favorites.clone(),
+                hide_sidebar: slide_bar_bool,
             },
         };
         // only save while there's a lock on PersistedState


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
This makes the chat window responsive at 600px, and adds something to the global state to indicate if we want to show or hide the side bar (so it can be used soon in all the different places a user might need it).

Currently only implemented in the chat window as the structure of some of the other things, like files and chat, need to be modified to make them responsive

### Which issue(s) this PR fixes 🔨
- Resolve #282
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
- I need to make things in the chat window responsive during resize, and then implement this in the other screens.
- I looked at the CPU usage and it doesn't appear this is affecting things any more than the base dev branch, but i may be wrong

https://user-images.githubusercontent.com/2993032/201487833-f1e1a87c-fa2c-46f7-b80d-427ffc11983c.mov


### Additional comments 🎤
I went in and fixed the things the github action for `Continuous integration / Rustfmt (pull_request)` was complaining about

