### PR TITLE
fix re-render in friends and add debug logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ linkify = "0.9.0"
 open = "3.0.3"
 pulldown-cmark = "0.9.2"
 regex = "1.6.0"
+log = "0.4.17"
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { default-features = false, features = [
     "std-future",

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ It's often necessary to reset your account for development, to do so just delete
 
 If you see something about cmake or protoc then you likely need to install those and get them in your path. Often times just restarting your shell helps. Other errors are fixed with updating packages `cargo update` or getting the nightly `rustup update; rustup default nightly` or stable `rustup update; rustup default stable` version of rust.
 
+## Debugging
+- run uplink as follows: `RUST_LOG=debug target/debug/uplink`
+- in another terminal (by default `~/.warp/logs`), tail the log file, follow it, and grep for `uplink`: `tail -f <file_name> | grep uplink`
+
 ## Contributions
 
 All contributions are welcome! Please keep in mind we're still a relatively small team and any work done to make sure contributions don't cause bugs or issues in the application is much appreciated.

--- a/src/components/main/compose/messages/mod.rs
+++ b/src/components/main/compose/messages/mod.rs
@@ -20,6 +20,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Messages(cx: Scope<Props>) -> Element {
+    log::debug!("rendering Messages");
     //Note: We will just unwrap for now though we need to
     //      handle the error properly if there is ever one when
     //      getting own identity
@@ -91,6 +92,7 @@ pub fn Messages(cx: Scope<Props>) -> Element {
 
         //This is to prevent the future updating the state and causing a rerender
         if *list.read() != messages {
+            log::debug!("updating messages list ");
             *list.write() = messages;
         }
 
@@ -107,6 +109,7 @@ pub fn Messages(cx: Scope<Props>) -> Element {
                     if current_chat.conversation.id() == conversation_id {
                         match rg.get_message(conversation_id, message_id).await {
                             Ok(message) => {
+                                log::debug!("compose/messages streamed a new message ");
                                 list.write().push(message.clone());
                                 // todo: add message to chats sidebar
                                 current_chat.last_msg_sent =

--- a/src/components/main/compose/mod.rs
+++ b/src/components/main/compose/mod.rs
@@ -25,6 +25,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Compose(cx: Scope<Props>) -> Element {
+    log::debug!("rendering Compose");
     let state = use_atom_ref(&cx, STATE);
     let current_chat = state.read().current_chat;
     let l = use_atom_ref(&cx, LANGUAGE).read();

--- a/src/components/main/compose/msg/embeds/mod.rs
+++ b/src/components/main/compose/msg/embeds/mod.rs
@@ -12,6 +12,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn LinkEmbed(cx: Scope<Props>) -> Element {
+    log::debug!("rendering LinkEmbed");
     cx.render(rsx! {
         if cx.props.meta.title.is_empty() {
             rsx! { span {""} }

--- a/src/components/main/compose/msg/mod.rs
+++ b/src/components/main/compose/msg/mod.rs
@@ -35,6 +35,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
+    log::debug!("rendering compose/Msg");
     let finder = LinkFinder::new();
     let content = cx.props.message.value();
     let joined_a = content.join("\n");
@@ -178,6 +179,7 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
 
                                     popout.set(false);
                                 },
+                                on_trigger_typing:  |_| {},
                                 text: text.clone(),
                             },
                             IconButton {

--- a/src/components/main/compose/reply/mod.rs
+++ b/src/components/main/compose/reply/mod.rs
@@ -15,6 +15,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Reply(cx: Scope<Props>) -> Element {
+    log::debug!("rendering compose/Reply");
     let class = if cx.props.is_remote {
         "remote"
     } else {

--- a/src/components/main/compose/topbar/mod.rs
+++ b/src/components/main/compose/topbar/mod.rs
@@ -23,6 +23,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn TopBar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering compose/TopBar");
     let state = use_atom_ref(&cx, STATE);
     let config = Config::load_config_or_default();
     let mut favorites = state.read().favorites.clone();

--- a/src/components/main/compose/write/mod.rs
+++ b/src/components/main/compose/write/mod.rs
@@ -18,6 +18,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering compose/Write");
     let config = Config::load_config_or_default();
     let text = use_state(&cx, String::new);
     let l = use_atom_ref(&cx, LANGUAGE).read();
@@ -31,6 +32,7 @@ pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             },
             TextArea {
                 on_submit: |val| cx.props.on_submit.call(val),
+                on_trigger_typing: |_| {},
                 text: text.clone(),
                 placeholder: l.chatbar_placeholder.to_string()
             }

--- a/src/components/main/friends/friend/mod.rs
+++ b/src/components/main/friends/friend/mod.rs
@@ -23,6 +23,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Friend<'a>(cx: Scope<'a, Props>) -> Element<'a> {
+    log::debug!("rendering Friend");
     let state = use_atom_ref(&cx, STATE);
 
     let mp = cx.props.account.clone();

--- a/src/components/main/friends/mod.rs
+++ b/src/components/main/friends/mod.rs
@@ -19,6 +19,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Friends(cx: Scope<Props>) -> Element {
+    log::debug!("rendering Friends");
     let add_error = use_state(&cx, String::new);
     let friends = use_state(&cx, || {
         HashSet::from_iter(cx.props.account.list_friends().unwrap_or_default())
@@ -33,6 +34,7 @@ pub fn Friends(cx: Scope<Props>) -> Element {
                     HashSet::from_iter(mp.read().list_friends().unwrap_or_default());
 
                 if *friends != friends_list {
+                    log::debug!("updating friends list ");
                     friends.set(friends_list);
                 }
 

--- a/src/components/main/friends/request/mod.rs
+++ b/src/components/main/friends/request/mod.rs
@@ -23,6 +23,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn FriendRequest<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering FriendRequest");
     let mp = cx.props.account.clone();
 
     let did = if cx.props.deny_only {

--- a/src/components/main/friends/sidebar/mod.rs
+++ b/src/components/main/friends/sidebar/mod.rs
@@ -22,6 +22,7 @@ use warp::multipass::Friends;
 #[inline_props]
 #[allow(non_snake_case)]
 pub fn Sidebar(cx: Scope, account: Account, add_error: UseState<String>) -> Element {
+    log::debug!("rendering friends/Sidebar");
     let l = use_atom_ref(&cx, LANGUAGE).read();
     let incomingRequestsLang = { l.incoming_requests.to_string() };
     let outgoingRequestsLang = { l.outgoing_requests.to_string() };
@@ -44,10 +45,12 @@ pub fn Sidebar(cx: Scope, account: Account, add_error: UseState<String>) -> Elem
                     HashSet::from_iter(account.read().list_outgoing_request().unwrap_or_default());
 
                 if *incoming != incoming_list {
+                    log::debug!("updating incoming friend requests ");
                     incoming.set(incoming_list);
                 }
 
                 if *outgoing != outgoing_list {
+                    log::debug!("updating outgoing friend requests ");
                     outgoing.set(outgoing_list);
                 }
 

--- a/src/components/main/mod.rs
+++ b/src/components/main/mod.rs
@@ -25,6 +25,7 @@ pub struct Prop {
 
 #[allow(non_snake_case)]
 pub fn Main(cx: Scope<Prop>) -> Element {
+    log::debug!("rendering Main");
     let st = use_atom_ref(&cx, STATE).clone();
     let rg = cx.props.messaging.clone();
     let state = use_atom_ref(&cx, STATE);
@@ -49,6 +50,7 @@ pub fn Main(cx: Scope<Prop>) -> Element {
                     current_conversations.insert(item.id(), to_insert);
                 }
                 if current_conversations != st.read().all_chats {
+                    log::debug!("modifying chats");
                     st.write()
                         .dispatch(Actions::AddRemoveConversations(current_conversations));
                 }

--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -53,7 +53,6 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         .unwrap_or_default();
 
     cx.render(rsx! {
-    "Profile"
         Popup {
             on_dismiss: |_| cx.props.on_hide.call(()),
             hidden: !cx.props.show,

--- a/src/components/main/profile/mod.rs
+++ b/src/components/main/profile/mod.rs
@@ -4,6 +4,8 @@ use crate::{
 };
 use dioxus::prelude::*;
 use dioxus_heroicons::{outline::Shape, Icon};
+use std::collections::HashSet;
+use warp::crypto::DID;
 
 #[derive(Props)]
 pub struct Props<'a> {
@@ -14,6 +16,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering Profile");
     // Read their values from locks
     let mp = cx.props.account.clone();
 
@@ -27,126 +30,126 @@ pub fn Profile<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
     let username = my_identity.username();
     let badges = my_identity.available_badges();
-    let friends = use_state(&cx, || mp.read().list_friends().unwrap_or_default());
-    let friend_count = use_state(&cx, || friends.clone().len());
+    let friends: &UseState<HashSet<DID>> = use_state(&cx, || {
+        HashSet::from_iter(mp.read().list_friends().unwrap_or_default().iter().cloned())
+    });
+    let friend_count = friends.current().len();
     //let identity = mp.read().get_own_identity().unwrap();
     //identity.set_graphics(identity.graphics().)
 
-    use_future(
-        &cx,
-        (friends, &mp, friend_count),
-        |(friends, mp, friend_count)| async move {
-            loop {
-                let list = mp.read().list_friends().unwrap_or_default();
-                if *friends != list {
-                    friend_count.set(list.len());
-                    friends.set(list);
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    use_future(&cx, (friends, &mp), |(friends, mp)| async move {
+        loop {
+            let list =
+                HashSet::from_iter(mp.read().list_friends().unwrap_or_default().iter().cloned());
+            if *friends.current() != list {
+                log::debug!("modifying friends list");
+                friends.set(list);
             }
-        },
-    );
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        }
+    });
     let status = my_identity.status_message().unwrap_or_default();
     let profile_picture = utils::get_pfp_from_did(my_identity.did_key(), &cx.props.account.clone())
         .unwrap_or_default();
 
     cx.render(rsx! {
-            Popup {
-                on_dismiss: |_| cx.props.on_hide.call(()),
-                hidden: !cx.props.show,
-                children: cx.render(
-                    rsx!(
+    "Profile"
+        Popup {
+            on_dismiss: |_| cx.props.on_hide.call(()),
+            hidden: !cx.props.show,
+            children: cx.render(
+                rsx!(
+                    div {
+                        class: "profile",
                         div {
-                            class: "profile",
-                            div {
-                                class: "background",
-                                if !profile_picture.is_empty() {
-                                    rsx!(
-                                        img {
-                                            class: "profile-photo",
-                                            src: "{profile_picture}",
-                                            height: "100",
-                                            width: "100",
+                            class: "background",
+                            if !profile_picture.is_empty() {
+                                rsx!(
+                                    img {
+                                        class: "profile-photo",
+                                        src: "{profile_picture}",
+                                        height: "100",
+                                        width: "100",
+                                    }
+                                )
+                            } else {
+                                rsx!(
+                                    div {
+                                        class: "profile-photo",
+                                        rsx! {
+                                            Icon {
+                                                size: 40,
+                                                icon: Shape::User,
+                                            },
                                         }
-                                    )
-                                } else {
-                                    rsx!(
-                                        div {
-                                            class: "profile-photo",
-                                            rsx! {
-                                                Icon {
-                                                    size: 40,
-                                                    icon: Shape::User,
-                                                },
-                                            }
-                                        }
-                                    )
-                                }
+                                    }
+                                )
+                            }
+                        },
+                        div {
+                            class: "profile-body",
+                            h3 {
+                                class: "username",
+                                "{username}"
+                            },
+                            p {
+                                class: "status",
+                                "{status}, here is status"
+                            },
+                            Button {
+                                text: l.edit_profile.to_string(),
+                                icon: Shape::PencilAlt,
+                                on_pressed: move |_| {
+                                    use_router(&cx).push_route("/main/settings/profile", None, None);
+                                },
                             },
                             div {
-                                class: "profile-body",
-                                h3 {
-                                    class: "username",
-                                    "{username}"
-                                },
-                                p {
-                                    class: "status",
-                                    "{status}, here is status"
-                                },
-                                Button {
-                                    text: l.edit_profile.to_string(),
-                                    icon: Shape::PencilAlt,
-                                    on_pressed: move |_| {
-                                        use_router(&cx).push_route("/main/settings/profile", None, None);
-                                    },
-                                },
+                                class: "meta",
                                 div {
-                                    class: "meta",
-                                    div {
-                                        class: "badges",
-                                        label {
-                                            "{badgesString}"
-                                        },
-                                        div {
-                                            class: "container",
-                                            badges.iter().map(|_badge| rsx!(
-                                                Badge {},
-                                            ))
-                                        }
+                                    class: "badges",
+                                    label {
+                                        "{badgesString}"
                                     },
                                     div {
-                                        class: "location",
-                                        label {
-                                            "{locationString}"
-                                        },
-                                        p {
-                                            "Unknown"
-                                        }
-                                    },
-                                    div {
-                                        class: "friend-count",
-                                        label {
-                                            "{friendString}"
-                                        }
-                                        p {
-                                            "{friend_count}"
-                                        }
+                                        class: "container",
+                                        badges.iter().map(|_badge| rsx!(
+                                            Badge {},
+                                        ))
                                     }
                                 },
-                                hr {},
                                 div {
-                                    class: "about",
+                                    class: "location",
                                     label {
-                                        "{aboutString}"
+                                        "{locationString}"
                                     },
                                     p {
-                                        "{noAboutString}",
+                                        "Unknown"
                                     }
                                 },
-                            }
+                                div {
+                                    class: "friend-count",
+                                    label {
+                                        "{friendString}"
+                                    }
+                                    p {
+                                        "{friend_count}"
+                                    }
+                                }
+                            },
+                            hr {},
+                            div {
+                                class: "about",
+                                label {
+                                    "{aboutString}"
+                                },
+                                p {
+                                    "{noAboutString}",
+                                }
+                            },
                         }
-                    )
+                    }
                 )
-            },
-        })
+            )
+        },
+    })
 }

--- a/src/components/main/settings/mod.rs
+++ b/src/components/main/settings/mod.rs
@@ -18,6 +18,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Settings(cx: Scope<Props>) -> Element {
+    log::debug!("rendering Settings");
     let page_to_open_on_settings = match cx.props.page_to_open {
         NavEvent::Profile => NavEvent::Profile,
         NavEvent::Developer => NavEvent::Developer,

--- a/src/components/main/settings/pages/developer/mod.rs
+++ b/src/components/main/settings/pages/developer/mod.rs
@@ -19,6 +19,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Developer(cx: Scope<Props>) -> Element {
+    log::debug!("rendering settings/pages/Developer");
     let mut config = Config::load_config_or_default();
     let c = config.clone();
 

--- a/src/components/main/settings/pages/general/mod.rs
+++ b/src/components/main/settings/pages/general/mod.rs
@@ -9,6 +9,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn General(cx: Scope<Props>) -> Element {
+    log::debug!("rendering settings/pages/General");
     let mut config = Config::load_config_or_default();
 
     cx.render(rsx! {

--- a/src/components/main/settings/pages/profile/mod.rs
+++ b/src/components/main/settings/pages/profile/mod.rs
@@ -15,6 +15,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Profile(cx: Scope<Props>) -> Element {
+    log::debug!("rendering settings/pages/Profile");
     let l = use_atom_ref(&cx, LANGUAGE).read();
     let edit = use_state(&cx, || false);
     let status = use_state(&cx, String::new);

--- a/src/components/main/settings/sidebar/mod.rs
+++ b/src/components/main/settings/sidebar/mod.rs
@@ -19,6 +19,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn SettingsSidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering SettingsSidebar");
     let initial_value = match cx.props.initial_value {
         NavEvent::Profile => NavEvent::Profile,
         NavEvent::Developer => NavEvent::Developer,

--- a/src/components/main/settings/sidebar/nav/mod.rs
+++ b/src/components/main/settings/sidebar/nav/mod.rs
@@ -48,6 +48,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Nav<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering settings/sidebar/Nav ");
     let initial_value = match cx.props.initial_value {
         NavEvent::Profile => NavEvent::Profile,
         NavEvent::Developer => NavEvent::Developer,

--- a/src/components/main/sidebar/chat/mod.rs
+++ b/src/components/main/sidebar/chat/mod.rs
@@ -28,6 +28,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Chat<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering main/sidebar/Chat");
     let state = use_atom_ref(&cx, STATE).clone();
     let l = use_atom_ref(&cx, LANGUAGE).read();
     // must be 'moved' into the use_future. don't pass it as a dependency because that won't work with
@@ -106,6 +107,7 @@ pub fn Chat<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             loop {
                 if let Ok(current_status) = account.identity_status(&remote_did) {
                     if *online_status.current() != current_status {
+                        log::debug!("updating online_status ");
                         online_status.set(current_status);
                     }
                 }
@@ -121,6 +123,7 @@ pub fn Chat<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
         |(mut conversation_info, is_active)| async move {
             if is_active {
                 if *unread_count.current() != 0 {
+                    log::debug!("sidebar/chat exiting future ");
                     unread_count.set(0);
                 }
                 // very important: don't open two message streams - if this is the active chat, the messages Element will read the stream and this
@@ -130,6 +133,7 @@ pub fn Chat<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 
             let num_unread_messages = conversation_info.num_unread_messages;
             if *unread_count.current() != num_unread_messages {
+                log::debug!("updating num_unread_messages ");
                 unread_count.set(num_unread_messages);
             }
 
@@ -163,6 +167,7 @@ pub fn Chat<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 {
                     match rg.get_message(conversation_id, message_id).await {
                         Ok(msg) => {
+                            log::debug!("sidebar/chat streamed a message");
                             tx_chan.send(msg.clone());
                             unread_count.modify(|x| x + 1);
                             // will silently remain zero if you only use *unread_count

--- a/src/components/main/sidebar/favorites/mod.rs
+++ b/src/components/main/sidebar/favorites/mod.rs
@@ -17,6 +17,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Favorites(cx: Scope<Props>) -> Element {
+    log::debug!("rendering main/sidebar/Favorites");
     let state = use_atom_ref(&cx, STATE);
     let state2 = state.clone();
     let state3 = state2.clone();
@@ -139,6 +140,7 @@ pub fn ConversationList<'a>(
     all_chats: HashMap<Uuid, ConversationInfo>,
     on_pressed: EventHandler<'a, Uuid>,
 ) -> Element<'a> {
+    log::debug!("rendering ConversationList");
     cx.render(rsx!(
        div {
         class: "add-favorites",

--- a/src/components/main/sidebar/mod.rs
+++ b/src/components/main/sidebar/mod.rs
@@ -30,6 +30,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Sidebar(cx: Scope<Props>) -> Element {
+    log::debug!("rendering main/Sidebar");
     let config = Config::load_config_or_default();
     let mp = cx.props.account.clone();
 

--- a/src/components/main/welcome/mod.rs
+++ b/src/components/main/welcome/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 
 #[allow(non_snake_case)]
 pub fn Welcome(cx: Scope) -> Element {
+    log::debug!("rendering Welcome");
     let l = use_atom_ref(&cx, LANGUAGE).read();
 
     cx.render(rsx! {

--- a/src/components/prelude/auth/mod.rs
+++ b/src/components/prelude/auth/mod.rs
@@ -21,6 +21,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Auth(cx: Scope<Props>) -> Element {
+    log::debug!("rendering Auth");
     let window = use_window(&cx);
     let l = use_atom_ref(&cx, LANGUAGE).read();
 

--- a/src/components/prelude/loading.rs
+++ b/src/components/prelude/loading.rs
@@ -16,6 +16,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Loading(cx: Scope<Props>) -> Element {
+    log::debug!("rendering Loading");
     let config = Config::load_config_or_default();
     let window = use_window(&cx);
     let loaded = use_state(&cx, || false);

--- a/src/components/prelude/unlock/mod.rs
+++ b/src/components/prelude/unlock/mod.rs
@@ -22,6 +22,7 @@ pub struct UnlockProps {
 
 #[allow(non_snake_case)]
 pub fn Unlock(cx: Scope<UnlockProps>) -> Element {
+    log::debug!("rendering Unlock");
     let l = use_atom_ref(&cx, LANGUAGE).read();
     let l2 = l.clone();
 

--- a/src/components/reusable/nav/mod.rs
+++ b/src/components/reusable/nav/mod.rs
@@ -26,6 +26,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Nav(cx: Scope<Props>) -> Element {
+    log::debug!("rendering reusable Nav");
     let multipass = cx.props.account.clone();
     let reqCount = use_state(&cx, || {
         multipass.list_incoming_request().unwrap_or_default().len()
@@ -51,6 +52,7 @@ pub fn Nav(cx: Scope<Props>) -> Element {
             loop {
                 let list = multipass.list_incoming_request().unwrap_or_default();
                 if list.len() != *reqCount.get() {
+                    log::debug!("updating friend request count");
                     reqCount.set(list.len());
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(300)).await;

--- a/src/components/reusable/sidebar/mod.rs
+++ b/src/components/reusable/sidebar/mod.rs
@@ -14,6 +14,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Sidebar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering reusable Sidebar");
     let config = Config::load_config_or_default();
 
     cx.render(rsx! {

--- a/src/components/reusable/toolbar/mod.rs
+++ b/src/components/reusable/toolbar/mod.rs
@@ -8,6 +8,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Toolbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering reusable Toolbar");
     cx.render(rsx! {
         div {
             id: "toolbar",

--- a/src/components/ui_kit/activity_indicator/mod.rs
+++ b/src/components/ui_kit/activity_indicator/mod.rs
@@ -12,6 +12,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn ActivityIndicator(cx: Scope<Props>) -> Element {
+    log::debug!("rendering ActivityIndicator");
     let status = use_state(&cx, || IdentityStatus::Offline);
 
     let account = cx.props.account.clone();
@@ -21,6 +22,7 @@ pub fn ActivityIndicator(cx: Scope<Props>) -> Element {
         loop {
             if let Ok(current_status) = account.identity_status(&remote_did) {
                 if *status != current_status {
+                    log::debug!("Updating activity indicator");
                     status.set(current_status);
                 }
             }

--- a/src/components/ui_kit/icon_input/mod.rs
+++ b/src/components/ui_kit/icon_input/mod.rs
@@ -21,6 +21,7 @@ pub struct Props<'a> {
 // todo: stop re-rendering this element (and the parent element) on every keystroke
 #[allow(non_snake_case)]
 pub fn IconInput<'a>(cx: Scope<'a, Props>) -> Element<'a> {
+    log::debug!("rendering IconInput");
     cx.render(match &cx.props.value {
         Some(value) => rsx! {
             div {

--- a/src/components/ui_kit/popup/mod.rs
+++ b/src/components/ui_kit/popup/mod.rs
@@ -12,6 +12,7 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Popup<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering Popup");
     let full = use_state(&cx, || false);
     let modal = use_state(&cx, || false);
     let show_children = use_state(&cx, || true);

--- a/src/components/ui_kit/textarea/mod.rs
+++ b/src/components/ui_kit/textarea/mod.rs
@@ -13,9 +13,11 @@ use dioxus_html::KeyCode;
 pub fn TextArea<'a>(
     cx: Scope,
     on_submit: EventHandler<'a, String>,
+    on_trigger_typing: EventHandler<'a, ()>,
     text: UseState<String>,
     placeholder: String,
 ) -> Element<'a> {
+    log::debug!("rendering TextArea");
     let clearing_state = &*cx.use_hook(|_| std::cell::Cell::new(false));
 
     let mut inner_html = cx.use_hook(|_| " ").clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use clap::Parser;
 use core::time;
 use dioxus::desktop::tao;
-use std::ops::{Deref, DerefMut};
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::thread;
+use std::{
+    ops::{Deref, DerefMut},
+    path::PathBuf,
+    sync::Arc,
+    thread,
+};
 use tracing_subscriber::EnvFilter;
 
 use dioxus::router::{Route, Router};


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Add debug messages for each time a component gets rendered. Fix a continuous re-render in the Profile Element, caused by the friends list coming from Warp in a different order every time. Needed to use a HashSet to compare lists.
- the bug was fixed in `profile/mod.rs`. the rest is just debugging. 

### Which issue(s) this PR fixes 🔨
- Resolve #

### Special notes for reviewers 🗒️


### Additional comments 🎤
