### PR TITLE
feat(notification): notify for incoming friend request

### DIFF
--- a/src/components/main/compose/msg/mod.rs
+++ b/src/components/main/compose/msg/mod.rs
@@ -175,7 +175,6 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
 
                                     popout.set(false);
                                 },
-                                on_trigger_typing:  |_| {},
                                 text: text.clone(),
                             },
                             IconButton {

--- a/src/components/main/compose/write/mod.rs
+++ b/src/components/main/compose/write/mod.rs
@@ -29,7 +29,6 @@ pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             },
             TextArea {
                 on_submit: |val| cx.props.on_submit.call(val),
-                on_trigger_typing: |_| {},
                 text: text.clone(),
                 placeholder: l.chatbar_placeholder.to_string()
             }

--- a/src/components/main/files/upload/mod.rs
+++ b/src/components/main/files/upload/mod.rs
@@ -1,10 +1,10 @@
-use std::{path::Path};
+use std::path::Path;
 
-use dioxus::{events::MouseEvent, prelude::*, core::to_owned};
+use dioxus::{core::to_owned, events::MouseEvent, prelude::*};
 use dioxus_heroicons::outline::Shape;
 
-use ui_kit::icon_button::IconButton;
 use rfd::FileDialog;
+use ui_kit::icon_button::IconButton;
 
 #[derive(Props)]
 pub struct Props<'a> {
@@ -40,7 +40,7 @@ pub fn Upload<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             .to_str()
                             .unwrap()
                             .to_string();
-                            
+
                             cx.spawn({
                                 to_owned![file_storage, file_path, filename];
                                 async move {
@@ -62,17 +62,17 @@ pub fn Upload<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                                         .to_str()
                                                         .unwrap()
                                                         .to_string();
-        
+
                                                         let file_extension = std::path::Path::new(&filename.clone())
                                                         .extension()
                                                         .unwrap_or_else(|| std::ffi::OsStr::new(""))
                                                         .to_str()
                                                         .unwrap()
                                                         .to_string();
-        
+
                                                         filename_to_save = format!("{} ({}).{}", file_name_without_extension, count_index_for_duplicate_filename, file_extension);
                                                         println!("Duplicate name, changing file name to {}", &filename_to_save);
-                                                    }, 
+                                                    },
                                                     _ => {
                                                         println!("Error to upload file: {:?}, error: {:?}", &filename_to_save, error);
                                                         break;
@@ -81,7 +81,7 @@ pub fn Upload<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                                 count_index_for_duplicate_filename += 1;
                                             },
                                         };
-                                    } 
+                                    }
                                 }
                             });
                         }

--- a/src/components/main/sidebar/mod.rs
+++ b/src/components/main/sidebar/mod.rs
@@ -49,7 +49,11 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
     let notifications_tx = use_coroutine(&cx, |mut rx: UnboundedReceiver<Message>| async move {
         while let Some(msg) = rx.next().await {
             let display_username = utils_internal::get_username_from_did(msg.sender().clone(), &mp);
-            PushNotification(display_username, msg.value().join("\n"));
+            PushNotification(
+                display_username,
+                msg.value().join("\n"),
+                crate::utils::sounds::Sounds::Notification,
+            );
         }
     });
 

--- a/src/components/main/sidebar/mod.rs
+++ b/src/components/main/sidebar/mod.rs
@@ -52,7 +52,7 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
             PushNotification(
                 display_username,
                 msg.value().join("\n"),
-                crate::utils::sounds::Sounds::Notification,
+                ::utils::sounds::Sounds::Notification,
             );
         }
     });

--- a/src/components/reusable/nav/mod.rs
+++ b/src/components/reusable/nav/mod.rs
@@ -7,7 +7,7 @@ use ui_kit::{
     numeric_indicator::NumericIndicator,
 };
 
-use crate::Account;
+use crate::{Account, LANGUAGE};
 use warp::multipass::{Friends, FriendsEvent, MultiPass, MultiPassEventKind};
 
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -27,6 +27,7 @@ pub struct Props {
 #[allow(non_snake_case)]
 pub fn Nav(cx: Scope<Props>) -> Element {
     log::debug!("rendering reusable Nav");
+    let l = use_atom_ref(&cx, LANGUAGE).read();
     let multipass = cx.props.account.clone();
     let reqCount = use_state(&cx, || {
         multipass.list_incoming_request().unwrap_or_default().len()
@@ -50,6 +51,7 @@ pub fn Nav(cx: Scope<Props>) -> Element {
         (reqCount, &multipass),
         |(reqCount, mut multipass)| async move {
             // Used to make sure everything is initalized before proceeding.
+
             let mut stream = loop {
                 match multipass.subscribe() {
                     Ok(stream) => break stream,
@@ -81,6 +83,7 @@ pub fn Nav(cx: Scope<Props>) -> Element {
                             None => from.to_string(),
                         };
                         PushNotification(
+                            // l.new_friend_request.to_string().to_owned(),
                             "New Friend Request".to_owned(),
                             format!("{} sent a friend request", name_or_did),
                             // "Come see who it is!".to_owned(),

--- a/src/components/reusable/nav/mod.rs
+++ b/src/components/reusable/nav/mod.rs
@@ -51,6 +51,7 @@ pub fn Nav(cx: Scope<Props>) -> Element {
         (reqCount, &multipass),
         |(reqCount, mut multipass)| async move {
             // Used to make sure everything is initalized before proceeding.
+            let new_friend_request_notification = l.new_friend_request.to_string().to_owned();
 
             let mut stream = loop {
                 match multipass.subscribe() {
@@ -83,7 +84,7 @@ pub fn Nav(cx: Scope<Props>) -> Element {
                             None => from.to_string(),
                         };
                         PushNotification(
-                            l.new_friend_request.to_string().to_owned(),
+                            new_friend_request_notification.clone(),
                             // "New Friend Request".to_owned(),
                             format!("{} sent a friend request", name_or_did),
                             // "Come see who it is!".to_owned(),
@@ -116,58 +117,9 @@ pub fn Nav(cx: Scope<Props>) -> Element {
                         };
                         reqCount.set(count);
                     }
-                    // left this commented out to allow for one to determine the logic here
-                    // MultiPassEventKind::FriendRequestClosed { from, .. } => {
-                    //     log::debug!("updating friend request count");
-                    //     let count = *(reqCount.get()) - 1;
-                    //     reqCount.set(count);
-                    // }
-                    // left commented out in the event one wants to use different logic or changes here
-                    // MultiPassEventKind::FriendAdded { did } => {
-                    //     let name_or_did = match multipass
-                    //         .get_identity(did.clone().into())
-                    //         .ok()
-                    //         .and_then(|list| list.first().cloned())
-                    //         .map(|id| id.username())
-                    //     {
-                    //         Some(name) => name,
-                    //         None => did.to_string(),
-                    //     };
-
-                    //     PushNotification(
-                    //         "New Friend".to_owned(),
-                    //         format!("You are now friends with {name_or_did}"),
-                    //         // format!("{:#?} sent a friend request", most_recent_friend_request),
-                    //         crate::utils::sounds::Sounds::FriendReq,
-                    //     );
-                    //     log::debug!("updating friend request count");
-                    //     let count = *(reqCount.get()) - 1;
-                    //     reqCount.set(count);
-                    // }
                     _ => {}
                 }
             }
-
-            // loop {
-            //     let list = multipass.list_incoming_request().unwrap_or_default();
-            //     if list.len() != *reqCount.get() {
-            //         // If list is updated, we update the request count
-            //         if list.len() > *reqCount.get() {
-            //             // We display a notification if the list length is increased (incoming request appended).
-            //             // We do not display a notification if the list length is decreased (incoming request is rejected).
-
-            //             PushNotification(
-            //                 "New Friend Request".to_owned(),
-            //                 "Come see who it is!".to_owned(),
-            //                 // format!("{:#?} sent a friend request", most_recent_friend_request),
-            //                 crate::utils::sounds::Sounds::FriendReq,
-            //             );
-            //         }
-
-            //         reqCount.set(list.len());
-            //     }
-            //     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-            // }
         },
     );
 

--- a/src/components/reusable/nav/mod.rs
+++ b/src/components/reusable/nav/mod.rs
@@ -27,7 +27,7 @@ pub struct Props {
 #[allow(non_snake_case)]
 pub fn Nav(cx: Scope<Props>) -> Element {
     log::debug!("rendering reusable Nav");
-    let l = use_atom_ref(&cx, LANGUAGE).read();
+    let l = use_atom_ref(&cx, LANGUAGE).read().clone();
     let multipass = cx.props.account.clone();
     let reqCount = use_state(&cx, || {
         multipass.list_incoming_request().unwrap_or_default().len()
@@ -83,8 +83,8 @@ pub fn Nav(cx: Scope<Props>) -> Element {
                             None => from.to_string(),
                         };
                         PushNotification(
-                            // l.new_friend_request.to_string().to_owned(),
-                            "New Friend Request".to_owned(),
+                            l.new_friend_request.to_string().to_owned(),
+                            // "New Friend Request".to_owned(),
                             format!("{} sent a friend request", name_or_did),
                             // "Come see who it is!".to_owned(),
                             ::utils::sounds::Sounds::FriendReq,

--- a/src/components/reusable/nav/mod.rs
+++ b/src/components/reusable/nav/mod.rs
@@ -1,12 +1,14 @@
+use ::utils::notifications::PushNotification;
 use dioxus::prelude::*;
 use dioxus_heroicons::outline::Shape;
+use futures::StreamExt;
 use ui_kit::{
     icon_button::{self, IconButton},
     numeric_indicator::NumericIndicator,
 };
 
 use crate::Account;
-use warp::multipass::Friends;
+use warp::multipass::{Friends, FriendsEvent, MultiPass, MultiPassEventKind};
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum NavEvent {
@@ -46,15 +48,123 @@ pub fn Nav(cx: Scope<Props>) -> Element {
     use_future(
         &cx,
         (reqCount, &multipass),
-        |(reqCount, multipass)| async move {
-            loop {
-                let list = multipass.list_incoming_request().unwrap_or_default();
-                if list.len() != *reqCount.get() {
-                    log::debug!("updating friend request count");
-                    reqCount.set(list.len());
+        |(reqCount, mut multipass)| async move {
+            // Used to make sure everything is initalized before proceeding.
+            let mut stream = loop {
+                match multipass.subscribe() {
+                    Ok(stream) => break stream,
+                    Err(e) => match e {
+                        //Note: Used as a precaution for future checks
+                        warp::error::Error::MultiPassExtensionUnavailable => {
+                            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                        }
+                        //TODO: log error
+                        //Note: Shouldnt give any other error but if it does to probably file as a bug
+                        _ => return,
+                    },
+                };
+            };
+
+            // one can process other events such as event sent, closed, accepted, etc
+            // Note: should only use events related to `FriendRequest` here
+            while let Some(event) = stream.next().await {
+                match event {
+                    MultiPassEventKind::FriendRequestReceived { from } => {
+                        // Use to show the name or did of who its from
+                        let name_or_did = match multipass
+                            .get_identity(from.clone().into())
+                            .ok()
+                            .and_then(|list| list.first().cloned())
+                            .map(|id| id.username())
+                        {
+                            Some(name) => name,
+                            None => from.to_string(),
+                        };
+                        PushNotification(
+                            "New Friend Request".to_owned(),
+                            format!("{} sent a friend request", name_or_did),
+                            // "Come see who it is!".to_owned(),
+                            ::utils::sounds::Sounds::FriendReq,
+                        );
+                        log::debug!("updating friend request count");
+                        let count = *(reqCount.get()) + 1;
+                        // Note, this will increase the counter. Maybe use a seperate task to check the list or use other events to decrease it
+                        reqCount.set(count);
+                    }
+                    MultiPassEventKind::FriendRequestRejected { .. } => {
+                        log::debug!("updating friend request count");
+                        let count = if *(reqCount.get()) == 0 {
+                            log::debug!("reject friend request");
+                            0
+                        } else {
+                            log::debug!("reject friend request");
+                            *(reqCount.get()) - 1
+                        };
+                        reqCount.set(count);
+                    }
+                    MultiPassEventKind::FriendRequestClosed { .. } => {
+                        log::debug!("updating friend request count");
+                        let count = if *(reqCount.get()) == 0 {
+                            log::debug!("close friend request");
+                            0
+                        } else {
+                            log::debug!("close friend request");
+                            *(reqCount.get()) - 1
+                        };
+                        reqCount.set(count);
+                    }
+                    // left this commented out to allow for one to determine the logic here
+                    // MultiPassEventKind::FriendRequestClosed { from, .. } => {
+                    //     log::debug!("updating friend request count");
+                    //     let count = *(reqCount.get()) - 1;
+                    //     reqCount.set(count);
+                    // }
+                    // left commented out in the event one wants to use different logic or changes here
+                    // MultiPassEventKind::FriendAdded { did } => {
+                    //     let name_or_did = match multipass
+                    //         .get_identity(did.clone().into())
+                    //         .ok()
+                    //         .and_then(|list| list.first().cloned())
+                    //         .map(|id| id.username())
+                    //     {
+                    //         Some(name) => name,
+                    //         None => did.to_string(),
+                    //     };
+
+                    //     PushNotification(
+                    //         "New Friend".to_owned(),
+                    //         format!("You are now friends with {name_or_did}"),
+                    //         // format!("{:#?} sent a friend request", most_recent_friend_request),
+                    //         crate::utils::sounds::Sounds::FriendReq,
+                    //     );
+                    //     log::debug!("updating friend request count");
+                    //     let count = *(reqCount.get()) - 1;
+                    //     reqCount.set(count);
+                    // }
+                    _ => {}
                 }
-                tokio::time::sleep(std::time::Duration::from_millis(300)).await;
             }
+
+            // loop {
+            //     let list = multipass.list_incoming_request().unwrap_or_default();
+            //     if list.len() != *reqCount.get() {
+            //         // If list is updated, we update the request count
+            //         if list.len() > *reqCount.get() {
+            //             // We display a notification if the list length is increased (incoming request appended).
+            //             // We do not display a notification if the list length is decreased (incoming request is rejected).
+
+            //             PushNotification(
+            //                 "New Friend Request".to_owned(),
+            //                 "Come see who it is!".to_owned(),
+            //                 // format!("{:#?} sent a friend request", most_recent_friend_request),
+            //                 crate::utils::sounds::Sounds::FriendReq,
+            //             );
+            //         }
+
+            //         reqCount.set(list.len());
+            //     }
+            //     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            // }
         },
     );
 

--- a/src/language/en_us.rs
+++ b/src/language/en_us.rs
@@ -54,5 +54,6 @@ pub fn make() -> Language {
         no_active_chats: String::from("No active chats, yet..."),
         start_one: String::from("Start one"),
         auth_tooltip: String::from("Only four to six characters allowed"),
+        new_friend_request: String::from("New Friend Request"),
     }
 }

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -54,6 +54,7 @@ pub struct Language {
     pub no_active_chats: String,
     pub start_one: String,
     pub auth_tooltip: String,
+    pub new_friend_request: String,
 }
 
 impl Language {

--- a/src/ui_kit/src/textarea/mod.rs
+++ b/src/ui_kit/src/textarea/mod.rs
@@ -13,7 +13,6 @@ use dioxus_html::KeyCode;
 pub fn TextArea<'a>(
     cx: Scope,
     on_submit: EventHandler<'a, String>,
-    on_trigger_typing: EventHandler<'a, ()>,
     text: UseState<String>,
     placeholder: String,
 ) -> Element<'a> {

--- a/src/utils/src/notifications.rs
+++ b/src/utils/src/notifications.rs
@@ -1,15 +1,14 @@
+use crate::sounds::{Play, Sounds};
 use notify_rust::Notification;
-
-use crate::sounds;
 
 // Implementation to create and push new notifications
 #[allow(non_snake_case)]
-pub fn PushNotification(title: String, content: String) {
+pub fn PushNotification(title: String, content: String, notification_sound: Sounds) {
     let summary = format!("Uplink - {}", title);
     let _n = Notification::new()
         .summary(summary.as_ref())
-        .body(content.as_ref())
+        .body(&content)
         .show();
     // Play notification sound
-    sounds::Play(sounds::Sounds::Notification);
+    Play(notification_sound);
 }

--- a/src/utils/src/sounds.rs
+++ b/src/utils/src/sounds.rs
@@ -2,6 +2,7 @@ use soloud::*;
 
 pub enum Sounds {
     Notification,
+    FriendReq,
     General,
 }
 
@@ -12,6 +13,9 @@ pub fn Play(sound: Sounds) {
     match sound {
         Sounds::Notification => wav
             .load_mem(include_bytes!("../../../extra/assets/sounds/Ponderous.ogg"))
+            .unwrap(),
+        Sounds::FriendReq => wav
+            .load_mem(include_bytes!("../../../extra/assets/sounds/Success.ogg"))
             .unwrap(),
         Sounds::General => {}
     };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- When incoming friend request is increased, notify with sound from Success.ogg
- WIP Display name of sender incoming request sender

### Which issue(s) this PR fixes 🔨
- Resolve #297 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

The number indicator on the nav does not reset if we stay on that page. If we click on another page, the nav will re-render, and only then would the number indicator display the right amount of incoming requests. I will show examples in screenshots below, where only 2 requests are sent out but 4 are noted in the number indicator, why? Because I never clicked on another page (never re-render the nav)

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/34530026/202752859-5283d3b1-e4ca-452e-9bb4-2243f36f0c29.png">

>Two incoming requests

<img width="1506" alt="image" src="https://user-images.githubusercontent.com/34530026/202752950-4c289501-d7c9-4920-b7d0-6689a638b9a8.png">

>Reject one of the requests

<img width="1505" alt="image" src="https://user-images.githubusercontent.com/34530026/202753045-17906dad-b8ea-47b5-8b56-cf63ca561932.png">

>Get a false amount of incoming requests on the number indicator

<img width="616" alt="image" src="https://user-images.githubusercontent.com/34530026/202753148-5613d03c-c796-4587-821a-4348c4e04603.png">

>Click on another page and the nav rerenders with the right number


### Additional comments 🎤

Some of these codes were written by Darius. Thanks Darius!

