### PR TITLE
chore(notifications): add dock badge method

### DIFF
--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -13,3 +13,7 @@ dioxus = { version = "0.2.4", features = ["desktop", "router", "fermi"] }
 libloading = "0.7.3"
 once_cell = "1.13"
 dirs = "4.0.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.24.1"
+objc = "0.2.7"

--- a/src/utils/src/notifications.rs
+++ b/src/utils/src/notifications.rs
@@ -1,6 +1,9 @@
 use crate::sounds::{Play, Sounds};
 use notify_rust::Notification;
 
+#[cfg(target_os = "macos")]
+use objc::{msg_send, sel, sel_impl};
+
 // Implementation to create and push new notifications
 #[allow(non_snake_case)]
 pub fn PushNotification(title: String, content: String, notification_sound: Sounds) {
@@ -11,4 +14,20 @@ pub fn PushNotification(title: String, content: String, notification_sound: Soun
         .show();
     // Play notification sound
     Play(notification_sound);
+}
+
+pub fn set_badge(count: u32) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        use cocoa::{appkit::NSApp, base::nil, foundation::NSString};
+
+        let label = if count == 0 {
+            nil
+        } else {
+            NSString::alloc(nil).init_str(&format!("{}", count))
+        };
+        let dock_tile: cocoa::base::id = msg_send![NSApp(), dockTile];
+        let _: cocoa::base::id = msg_send![dock_tile, setBadgeLabel: label];
+    }
+    Ok(())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
Adds the utility to add notification badge/count to macos dock.

To use in a file:
```
use ::utils::notifications::set_badge;
set_badge(count: <u32 value>);
```

I didn't implement this because unread counts/notifications/etc need to be moved outside of the component they are in to somewhere global/higher up

example:
![image](https://user-images.githubusercontent.com/2993032/202875305-d55258b6-6870-40b0-b70f-6d0bce166f6a.png)

TODO: Add functionality for windows/mac/mobile and hook up to a global state object when that is created

### Which issue(s) this PR fixes 🔨
- Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

