### PR TITLE
feat(settings): configure layout responsiveness for settings page

### DIFF
--- a/src/components/main/files/mod.rs
+++ b/src/components/main/files/mod.rs
@@ -7,6 +7,7 @@ use crate::{
         reusable::nav::Nav,
     },
     main::files::{browser::FileBrowser, toolbar::Toolbar, upload::Upload},
+    STATE,
 };
 pub mod browser;
 pub mod sidebar;
@@ -24,9 +25,16 @@ pub fn Files(cx: Scope<Props>) -> Element {
     let show_new_folder = use_state(&cx, || false);
     let show_upload = use_state(&cx, || false);
 
+    let st = use_atom_ref(&cx, STATE).clone();
+    let sidebar_visibility = match st.read().hide_sidebar {
+        false => "sidebar-visible",
+        true => "sidebar-hidden",
+    };
+
     cx.render(rsx! {
         div {
             id: "files",
+            class: "{sidebar_visibility}",
             sidebar::Sidebar { account: cx.props.account.clone() },
             div {
                 id: "content",

--- a/src/components/main/files/sidebar/mod.rs
+++ b/src/components/main/files/sidebar/mod.rs
@@ -3,7 +3,7 @@
 use dioxus::prelude::*;
 use dioxus_heroicons::{solid::Shape, Icon};
 
-use crate::Account;
+use crate::{state::Actions, Account, STATE};
 
 #[derive(Eq, PartialEq, Clone)]
 pub struct Directory {
@@ -32,11 +32,16 @@ pub enum FolderDisplay {
 #[allow(non_snake_case)]
 pub fn FileElem(cx: Scope, file: File) -> Element {
     let name = file.name.clone();
+    let st = use_atom_ref(&cx, STATE).clone();
+
     cx.render(rsx!(
         a {
             class: "tree_item",
             div {
                 class: "row",
+                onclick: move |_| {
+                    st.write().dispatch(Actions::HideSidebar(true));
+                },
                 Icon {
                     icon: Shape::Document,
                 },

--- a/src/components/main/files/toolbar/mod.rs
+++ b/src/components/main/files/toolbar/mod.rs
@@ -6,6 +6,8 @@ use crate::components::{
     main::files::toolbar::usage::{Usage, UsageStats},
     reusable::toolbar,
 };
+use crate::{state::Actions, STATE};
+
 pub mod usage;
 
 #[derive(Props)]
@@ -16,6 +18,8 @@ pub struct Props<'a> {
 
 #[allow(non_snake_case)]
 pub fn Toolbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    let st = use_atom_ref(&cx, STATE).clone();
+
     cx.render(rsx! {
         toolbar::Toolbar {
             controls: cx.render(rsx! {
@@ -34,13 +38,26 @@ pub fn Toolbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                     on_pressed: move |e| cx.props.on_show_upload.call(e)
                 }
             }),
-            Usage {
-                usage: UsageStats {
-                    available: 1256,
-                    total: 123456,
-                    used: 122200,
-                    percent_free: 75,
-                }
+            div {
+                class: "usage-container",
+                div {
+                    class: "mobile-back-button",
+                    IconButton {
+                        icon: Shape::ArrowLeft,
+                        state: ui_kit::icon_button::State::Secondary,
+                        on_pressed: move |_| {
+                            st.write().dispatch(Actions::HideSidebar(false));
+                        },
+                    },
+                },
+                Usage {
+                    usage: UsageStats {
+                        available: 1256,
+                        total: 123456,
+                        used: 122200,
+                        percent_free: 75,
+                    }
+                },
             },
         },
     })

--- a/src/components/main/files/toolbar/styles.scss
+++ b/src/components/main/files/toolbar/styles.scss
@@ -1,0 +1,3 @@
+.usage-container {
+  display: flex;
+}

--- a/src/components/main/mod.rs
+++ b/src/components/main/mod.rs
@@ -29,7 +29,7 @@ pub fn Main(cx: Scope<Prop>) -> Element {
     let rg = cx.props.messaging.clone();
     let state = use_atom_ref(&cx, STATE);
     let display_welcome = state.read().current_chat.is_none();
-    let hide_sidebar = match st.read().hide_sidebar {
+    let sidebar_visibility = match st.read().hide_sidebar {
         false => "main-sidebar",
         true => "main-chat",
     };
@@ -62,7 +62,7 @@ pub fn Main(cx: Scope<Prop>) -> Element {
 
     cx.render(rsx! {
         div {
-            class: "main {hide_sidebar}",
+            class: "main {sidebar_visibility}",
             rsx!(
                 Sidebar {
                     messaging: cx.props.messaging.clone(),

--- a/src/components/main/settings/mod.rs
+++ b/src/components/main/settings/mod.rs
@@ -4,8 +4,13 @@ use crate::{
     components::main::settings::pages::{
         developer::Developer, extensions::Extensions, general::General, profile::Profile,
     },
-    Account,
+    components::reusable::toolbar,
+    state::Actions,
+    Account, STATE,
 };
+
+use dioxus_heroicons::outline::Shape;
+use ui_kit::icon_button::IconButton;
 
 use self::sidebar::nav::Route;
 
@@ -20,6 +25,7 @@ pub struct Props {
 
 #[allow(non_snake_case)]
 pub fn Settings(cx: Scope<Props>) -> Element {
+    let st = use_atom_ref(&cx, STATE).clone();
     log::debug!("rendering Settings");
     let page_to_open_on_settings = match cx.props.page_to_open {
         Route::Profile => Route::Profile,
@@ -27,15 +33,33 @@ pub fn Settings(cx: Scope<Props>) -> Element {
         _ => Route::General,
     };
 
+    let sidebar_visibility = match st.read().hide_sidebar {
+        false => "sidebar-visible",
+        true => "sidebar-hidden",
+    };
+
     let active_page = use_state(&cx, || page_to_open_on_settings);
+
+    let active_page_string = match **active_page {
+        Route::Profile => "Profile",
+        Route::Privacy => "Privacy",
+        Route::AudioVideo => "Audio Video",
+        Route::Extensions => "Extensions",
+        Route::Developer => "Developer",
+        _ => "General",
+    };
 
     cx.render(rsx! {
         div {
             id: "settings",
+            class: "{sidebar_visibility}",
             sidebar::SettingsSidebar {
                 account: cx.props.account.clone(),
                 on_pressed: move |ne| {
                     active_page.set(ne);
+
+                    let state = use_atom_ref(&cx, STATE).clone();
+                    state.write().dispatch(Actions::HideSidebar(true));
                 },
                 initial_value: match active_page.get() {
                     Route::Profile => Route::Profile,
@@ -45,6 +69,37 @@ pub fn Settings(cx: Scope<Props>) -> Element {
             },
             div {
                 id: "content",
+                div {
+                    class: "toolbar-wrapper",
+                    toolbar::Toolbar {
+                        controls: cx.render(rsx! {
+                            div {}
+                        }),
+                        div {
+                            class: "toolbar-content",
+                            div {
+                                class: "toolbar-start",
+                                div {
+                                    class: "mobile-back-button",
+                                    IconButton {
+                                        icon: Shape::ArrowLeft,
+                                        state: ui_kit::icon_button::State::Secondary,
+                                        on_pressed: move |_| {
+                                            let state = use_atom_ref(&cx, STATE).clone();
+                                            state.write().dispatch(Actions::HideSidebar(false));
+                                        },
+                                    },
+                                },
+                            },
+                            h1 {
+                                "{active_page_string}",
+                            },
+                            div {
+                                class:  "toolbar-end",
+                            }
+                        }
+                    },
+                },
                 div {
                     id: "page",
                     div {

--- a/src/components/main/settings/style.scss
+++ b/src/components/main/settings/style.scss
@@ -7,15 +7,6 @@
   width: 100%;
   background-color: var(--theme-background);
 
-  .closer {
-    position: fixed;
-    z-index: 1;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-  }
-
   #content {
     background-color: var(--theme-background);
     border-radius: 4px;
@@ -25,6 +16,29 @@
     top: 2.5%;
     left: 2.5%;
     flex-direction: column;
+
+    .toolbar-wrapper {
+      margin-bottom: 0.2rem;
+      border-bottom: 1px solid var(--theme-borders);
+
+      #toolbar {
+        #content {
+          .toolbar-content {
+            display: flex;
+            flex-grow: 1;
+            justify-content: space-between;
+            align-items: center;
+
+            .toolbar-start,
+            .toolbar-end {
+              flex-grow: 1;
+              flex-basis: 0;
+            }
+          }
+        }
+      }
+    }
+
     #page {
       width: 100%;
       .wrapper {

--- a/src/components/main/styles.scss
+++ b/src/components/main/styles.scss
@@ -29,14 +29,17 @@
       height: 100%;
       position: absolute;
     }
+
     .compose {
       display: none;
     }
   }
+
   .main-chat {
     .sidebar {
       display: none;
     }
+
     .compose {
       width: 100%;
       height: 100%;
@@ -44,24 +47,44 @@
     }
   }
 
-  #files {
-    #sidebar {
-      display: none;
+  #files,
+  #settings {
+    &.sidebar-hidden {
+      #sidebar {
+        display: none;
+      }
+
+      #content {
+        width: 100%;
+        height: 100%;
+        position: relative;
+        justify-self: flex-end;
+      }
     }
-    #content {
-      width: 100%;
-      height: 100%;
-      position: relative;
-      justify-self: flex-end;
+
+    &.sidebar-visible {
+      #sidebar {
+        width: 100%;
+        height: 100%;
+        position: relative;
+        justify-self: flex-end;
+      }
+
+      #content {
+        display: none;
+      }
     }
   }
+
   .mobile-back-button {
     display: block;
     margin-right: 5px;
   }
+
   .hidden-on-desktop {
     display: block;
   }
+
   .show-on-desktop {
     display: none;
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Adds responsiveness and functionality to collapse and display sidebar for settings page.
- Adds header for sidebar page with working back button and dynamic title.
- Adds functionality to collapse and display sidebar for files page (with working back button).

### Which issue(s) this PR fixes 🔨
- Resolve #381 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->
