### PR TITLE
feat(settings): configure layout responsiveness for friends page

### DIFF
--- a/src/components/main/friends/sidebar/mod.rs
+++ b/src/components/main/friends/sidebar/mod.rs
@@ -1,4 +1,7 @@
-use crate::{components::main::friends::request::FriendRequest, Account, LANGUAGE, TOAST_MANAGER};
+use crate::{
+    components::main::friends::request::FriendRequest, state::Actions, Account, LANGUAGE, STATE,
+    TOAST_MANAGER,
+};
 
 use arboard::Clipboard;
 use dioxus::{
@@ -228,6 +231,17 @@ pub fn FindFriends(cx: Scope, account: Account, add_error: UseState<String>) -> 
                         Err(_) => add_error.set(l2.invalid_code.to_string()),
                     }
                 },
+            },
+            div {
+                class: "show-friends-button",
+                IconButton {
+                    icon: Shape::ArrowRight,
+                    state: ui_kit::icon_button::State::Secondary,
+                    on_pressed: move |_| {
+                        let state = use_atom_ref(&cx, STATE).clone();
+                        state.write().dispatch(Actions::HideSidebar(true));
+                    },
+                }
             }
         },
         div {

--- a/src/components/main/friends/sidebar/styles.scss
+++ b/src/components/main/friends/sidebar/styles.scss
@@ -27,12 +27,19 @@
       width: 100%;
       display: inline-flex;
       margin-bottom: 1rem;
+
       .icon-input {
         flex: 1;
       }
 
       .button {
-        margin-left: 1rem;
+        margin-left: 8px;
+      }
+
+      @media only screen and (min-width: 600px) {
+        .show-friends-button {
+          display: none;
+        }
       }
     }
   }

--- a/src/components/main/friends/styles.scss
+++ b/src/components/main/friends/styles.scss
@@ -7,6 +7,7 @@
   flex-direction: row;
 
   #content {
+    display: flex;
     flex: 1;
     min-width: 0;
     height: 100%;
@@ -14,6 +15,32 @@
     overflow-x: hidden;
     overflow-y: scroll;
     flex-direction: column;
+
+    .main {
+      display: flex;
+
+      .friends-list {
+        padding: 1rem;
+        flex-grow: 1;
+      }
+
+      .friends-separator {
+        align-items: center;
+        height: 12px;
+        width: calc(100% - 5rem);
+        margin: 4px 0px 16px 0px;
+        text-align: left;
+      }
+
+      ul {
+        list-style-type: none;
+        margin-right: 2px;
+        padding: 8px 4px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+      }
+    }
   }
 
   .a-z-list {
@@ -39,50 +66,6 @@
   @media only screen and (min-height: 650px) {
     ul {
       font-size: 16px;
-    }
-  }
-
-  ul {
-    list-style-type: none;
-    margin-right: 2px;
-    padding: 8px 8px 8px 0px;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-  }
-
-  .friends-separator {
-    align-items: center;
-    height: 12px;
-    width: calc(100% - 5rem);
-    margin: 4px 0px 16px 0px;
-    text-align: left;
-  }
-
-  .friends-list {
-    padding: 1rem;
-  }
-
-  .toolbar {
-    min-height: 0;
-    display: inline-flex;
-    padding: 0.5rem 1rem;
-    width: 100%;
-    flex-direction: row;
-    border-bottom: 1px solid var(--theme-borders);
-
-    .controls {
-      flex: 1;
-      height: 100%;
-      min-width: 0;
-      display: inline-flex;
-      flex-direction: row;
-      justify-content: flex-end;
-
-      .button {
-        margin-left: 0.25rem;
-        padding: 0 0.25rem;
-      }
     }
   }
 }

--- a/src/components/main/settings/mod.rs
+++ b/src/components/main/settings/mod.rs
@@ -5,13 +5,10 @@ use crate::{
         audio_video::AudioVideo, developer::Developer, extensions::Extensions, general::General,
         profile::Profile,
     },
-    components::reusable::toolbar,
+    components::reusable::page_header,
     state::Actions,
     Account, STATE,
 };
-
-use dioxus_heroicons::outline::Shape;
-use ui_kit::icon_button::IconButton;
 
 use self::sidebar::nav::Route;
 
@@ -70,36 +67,13 @@ pub fn Settings(cx: Scope<Props>) -> Element {
             },
             div {
                 id: "content",
-                div {
-                    class: "toolbar-wrapper",
-                    toolbar::Toolbar {
-                        controls: cx.render(rsx! {
-                            div {}
-                        }),
-                        div {
-                            class: "toolbar-content",
-                            div {
-                                class: "toolbar-start",
-                                div {
-                                    class: "mobile-back-button",
-                                    IconButton {
-                                        icon: Shape::ArrowLeft,
-                                        state: ui_kit::icon_button::State::Secondary,
-                                        on_pressed: move |_| {
-                                            let state = use_atom_ref(&cx, STATE).clone();
-                                            state.write().dispatch(Actions::HideSidebar(false));
-                                        },
-                                    },
-                                },
-                            },
-                            h1 {
-                                "{active_page_string}",
-                            },
-                            div {
-                                class:  "toolbar-end",
-                            }
-                        }
-                    },
+                page_header::PageHeader {
+                    content_start: cx.render(rsx! {Fragment()}),
+                    content_center: cx.render(rsx! {
+                        h1 { "{active_page_string}" }
+                    }),
+                    content_end: cx.render(rsx! {Fragment()}),
+                    hide_on_desktop: true,
                 },
                 div {
                     id: "page",

--- a/src/components/main/settings/style.scss
+++ b/src/components/main/settings/style.scss
@@ -17,28 +17,6 @@
     left: 2.5%;
     flex-direction: column;
 
-    .toolbar-wrapper {
-      margin-bottom: 0.2rem;
-      border-bottom: 1px solid var(--theme-borders);
-
-      #toolbar {
-        #content {
-          .toolbar-content {
-            display: flex;
-            flex-grow: 1;
-            justify-content: space-between;
-            align-items: center;
-
-            .toolbar-start,
-            .toolbar-end {
-              flex-grow: 1;
-              flex-basis: 0;
-            }
-          }
-        }
-      }
-    }
-
     #page {
       width: 100%;
       .wrapper {

--- a/src/components/main/settings/style.scss
+++ b/src/components/main/settings/style.scss
@@ -13,8 +13,6 @@
     display: inline-flex;
     flex: 1;
     z-index: 2;
-    top: 2.5%;
-    left: 2.5%;
     flex-direction: column;
 
     #page {

--- a/src/components/main/styles.scss
+++ b/src/components/main/styles.scss
@@ -48,6 +48,7 @@
   }
 
   #files,
+  #friends,
   #settings {
     &.sidebar-hidden {
       #sidebar {

--- a/src/components/reusable/mod.rs
+++ b/src/components/reusable/mod.rs
@@ -1,3 +1,4 @@
 pub mod nav;
 pub mod sidebar;
 pub mod toolbar;
+pub mod page_header;

--- a/src/components/reusable/page_header/mod.rs
+++ b/src/components/reusable/page_header/mod.rs
@@ -23,40 +23,40 @@ pub fn PageHeader<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     };
 
     cx.render(rsx! {
-				div {
-						id: "page-header",
-						class: "{header_visibility}",
-						toolbar::Toolbar {
-								controls: cx.render(rsx! {
-										div {}
-								}),
-								div {
-										class: "toolbar-content",
-										div {
-												class: "toolbar-start",
-												div {
-														class: "mobile-back-button",
-														IconButton {
-																icon: Shape::ArrowLeft,
-																state: ui_kit::icon_button::State::Secondary,
-																on_pressed: move |_| {
-																		let state = use_atom_ref(&cx, STATE).clone();
-																		state.write().dispatch(Actions::HideSidebar(false));
-																},
-														},
-												},
-												&cx.props.content_start
-										},
-										div {
-												class: "toolbar-center",
-												&cx.props.content_center
-										},
-										div {
-												class:  "toolbar-end",
-												&cx.props.content_end
-										},
-								}
-						},
-				},
+        div {
+            id: "page-header",
+            class: "{header_visibility}",
+            toolbar::Toolbar {
+                controls: cx.render(rsx! {
+                    div {}
+                }),
+                div {
+                    class: "toolbar-content",
+                    div {
+                        class: "toolbar-start",
+                        div {
+                            class: "mobile-back-button",
+                            IconButton {
+                                icon: Shape::ArrowLeft,
+                                state: ui_kit::icon_button::State::Secondary,
+                                on_pressed: move |_| {
+                                    let state = use_atom_ref(&cx, STATE).clone();
+                                    state.write().dispatch(Actions::HideSidebar(false));
+                                },
+                            },
+                        },
+                        &cx.props.content_start
+                    },
+                    div {
+                        class: "toolbar-center",
+                        &cx.props.content_center
+                    },
+                    div {
+                        class:  "toolbar-end",
+                        &cx.props.content_end
+                    },
+                }
+            },
+        },
     })
 }

--- a/src/components/reusable/page_header/mod.rs
+++ b/src/components/reusable/page_header/mod.rs
@@ -1,0 +1,62 @@
+use dioxus::prelude::*;
+
+use crate::{components::reusable::toolbar, state::Actions, STATE};
+
+use dioxus_heroicons::outline::Shape;
+use ui_kit::icon_button::IconButton;
+
+#[derive(Props)]
+pub struct Props<'a> {
+    content_start: Element<'a>,
+    content_center: Element<'a>,
+    content_end: Element<'a>,
+    hide_on_desktop: bool,
+}
+
+#[allow(non_snake_case)]
+pub fn PageHeader<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering PageHeading");
+
+    let header_visibility = match cx.props.hide_on_desktop {
+        true => "header-hidden",
+        false => "",
+    };
+
+    cx.render(rsx! {
+				div {
+						id: "page-header",
+						class: "{header_visibility}",
+						toolbar::Toolbar {
+								controls: cx.render(rsx! {
+										div {}
+								}),
+								div {
+										class: "toolbar-content",
+										div {
+												class: "toolbar-start",
+												div {
+														class: "mobile-back-button",
+														IconButton {
+																icon: Shape::ArrowLeft,
+																state: ui_kit::icon_button::State::Secondary,
+																on_pressed: move |_| {
+																		let state = use_atom_ref(&cx, STATE).clone();
+																		state.write().dispatch(Actions::HideSidebar(false));
+																},
+														},
+												},
+												&cx.props.content_start
+										},
+										div {
+												class: "toolbar-center",
+												&cx.props.content_center
+										},
+										div {
+												class:  "toolbar-end",
+												&cx.props.content_end
+										},
+								}
+						},
+				},
+    })
+}

--- a/src/components/reusable/page_header/styles.scss
+++ b/src/components/reusable/page_header/styles.scss
@@ -1,0 +1,27 @@
+#page-header {
+  margin-bottom: 0.2rem;
+  border-bottom: 1px solid var(--theme-borders);
+
+  @media only screen and (min-width: 600px) {
+    &.header-hidden {
+      display: none;
+    }
+  }
+
+  #toolbar {
+    #content {
+      .toolbar-content {
+        display: flex;
+        flex-grow: 1;
+        justify-content: space-between;
+        align-items: center;
+
+        .toolbar-start,
+        .toolbar-end {
+          flex-grow: 1;
+          flex-basis: 0;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Adds responsiveness and functionality to collapse and display sidebar for friends page.
- Refactors settings page header into separate component (page_header) and implements it in friends page. 
- Configures settings header so that it only shows on mobile layout.
- Fixes layout issues with the friends page content (needed to be restructured).

### Which issue(s) this PR fixes 🔨
- Resolve #382 
- Resolve #412 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
- As the scope of this PR was becoming too big, fixes to the "settings mobile padding" issue will be added in a separate PR (see [this comment](https://github.com/Satellite-im/Uplink/pull/394#issuecomment-1325672582))
- Similar PR to #394 
- Return button has been positioned next to the "Add Someone" button for now. Will probably need revision.
<img width="600" alt="スクリーンショット 2022-11-25 11 53 24" src="https://user-images.githubusercontent.com/40599535/203879772-1ac108b1-e525-44de-8ed0-2f4d1891e645.png">
<img width="463" alt="スクリーンショット 2022-11-25 11 53 39" src="https://user-images.githubusercontent.com/40599535/203879787-3ab6c77d-e47c-49c6-94a6-4edbcbc9791e.png">
