### PR TITLE
chore(chat): call ui responsive on resize

### DIFF
--- a/src/components/media/media.js
+++ b/src/components/media/media.js
@@ -1,0 +1,59 @@
+var media = document.getElementById("media-content")
+
+function setMediaSize(width, height) {
+  ;[...document.getElementsByClassName("media-user")].forEach((el) => {
+    el.style.width = `${width}px`
+    el.style.height = `${height}px`
+  })
+}
+
+function calculateMediaUserSize(entry) {
+  if (!media) return
+  const [width, height] = getOptimalBoxDimensions({
+    containerWidth: entry?.contentRect.width ?? media.clientWidth,
+    containerHeight: entry?.contentRect.height ?? media.clientHeight,
+    aspectRatio: 16 / 9,
+    numBoxes: document.getElementsByClassName("media-user").length,
+    gap: 16,
+  })
+
+  setMediaSize(width, height)
+}
+
+function getOptimalBoxDimensions(params) {
+  let prevWidth = 0
+  let prevHeight = 0
+  let width = 0
+  let height = 0
+  for (let numRows = 1; numRows <= params.numBoxes; numRows++) {
+    const numMaxCols = Math.ceil(params.numBoxes / numRows)
+    prevWidth = width
+    prevHeight = height
+    ;[width, height] = getBoxDimensionsForLayout(params, numMaxCols, numRows)
+    if (prevWidth > width) {
+      return [prevWidth, prevHeight]
+    }
+  }
+  return [width, height]
+}
+
+function getBoxDimensionsForLayout(params, numMaxCols, numRows) {
+  const rowGap = params.gap * (numRows - 1)
+  const colGap = params.gap * (numMaxCols - 1)
+  let boxWidth = (params.containerWidth - colGap) / numMaxCols
+  let boxHeight = boxWidth / params.aspectRatio
+  const contentHeight = boxHeight * numRows + rowGap
+  if (contentHeight > params.containerHeight) {
+    boxHeight = (params.containerHeight - rowGap) / numRows
+    boxWidth = boxHeight * params.aspectRatio
+  }
+  return [boxWidth, boxHeight]
+}
+
+var resizeObserver = new ResizeObserver((entries) => {
+  entries.forEach((entry) => {
+    calculateMediaUserSize(entry)
+  })
+})
+
+if (media) resizeObserver.observe(media)

--- a/src/components/media/mod.rs
+++ b/src/components/media/mod.rs
@@ -28,6 +28,8 @@ pub fn MediaContainer(cx: Scope<Props>) -> Element {
     let username = my_identity.username();
     let names = [username, String::from("Fake User")];
 
+    let script = include_str!("./media.js");
+
     cx.render(rsx! {
         div {
             id: "media-container",
@@ -61,6 +63,7 @@ pub fn MediaContainer(cx: Scope<Props>) -> Element {
                 },
             }
             Controls {}
+            script { "{script}" }
         }
     })
 }

--- a/src/components/media/styles.scss
+++ b/src/components/media/styles.scss
@@ -1,14 +1,16 @@
 #media-container {
-  width: 100%;
-  background: var(--theme-background);
-  display: inline-flex;
+  position: relative;
+  display: flex;
   flex-direction: column;
-  min-height: 300px;
+  flex-shrink: 0;
+  gap: 1rem;
+  padding-top: 1rem;
+  min-height: 240px;
   max-height: calc(100% - 15rem);
+  background: var(--theme-background);
   border-bottom: 1px solid var(--theme-borders);
   overflow-y: hidden;
   resize: vertical;
-  position: relative;
 
   &.fullscreen {
     position: fixed;
@@ -24,16 +26,21 @@
 
   .media-view {
     display: flex;
-    overflow-y: scroll;
+    overflow-y: hidden;
     flex: 1;
 
     #media-content {
-      flex: 1;
+      position: relative;
       display: flex;
-      flex-flow: row wrap;
+      flex: 1;
+      flex-wrap: wrap;
+      flex-direction: row;
       justify-content: center;
       align-content: center;
       gap: 1rem;
+      min-height: 120px;
+      margin: 0 12px;
+      overflow: hidden;
     }
 
     .media-toggle {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- The user media blocks are now responsive when resizing

### Which issue(s) this PR fixes 🔨
- Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
Used JS because the support for the ResizeObserver in Dioxus is still a WIP

Gonna add the presenter layout (when you click on a specific user block) as well in the next PR

### Additional comments 🎤

