### PR TITLE
Feat/(typing indicator): display an icon when someone in the conversation is typing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,10 @@ image = "0.24.5"
 ui_kit = { path = "src/ui_kit" }
 utils = { path = "src/utils" }
 
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb"}
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "e12cdd2c589286714142a7d892ab5b225ff41fc3"}
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "e12cdd2c589286714142a7d892ab5b225ff41fc3" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "e12cdd2c589286714142a7d892ab5b225ff41fc3" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "e12cdd2c589286714142a7d892ab5b225ff41fc3" }
 arboard = "3.1.0"
 fs2 = "0.4.3"
 humansize = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,10 @@ image = "0.24.5"
 ui_kit = { path = "src/ui_kit" }
 utils = { path = "src/utils" }
 
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb"}
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb" }
+warp = { git =         "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events"}
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }
 arboard = "3.1.0"
 fs2 = "0.4.3"
 humansize = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,10 @@ image = "0.24.5"
 ui_kit = { path = "src/ui_kit" }
 utils = { path = "src/utils" }
 
-warp = { git =         "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events"}
-warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }
-warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }
-warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb"}
+warp-mp-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb" }
+warp-rg-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb" }
+warp-fs-ipfs = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb" }
 arboard = "3.1.0"
 fs2 = "0.4.3"
 humansize = "2.0.0"

--- a/src/components/main/compose/messages/mod.rs
+++ b/src/components/main/compose/messages/mod.rs
@@ -342,6 +342,7 @@ pub fn Messages(cx: Scope<Props>) -> Element {
                     rsx! {
                         Msg {
                             // key: "{message_id}-reply",
+                            messaging: cx.props.messaging.clone(),
                             message: message.clone(),
                             account: cx.props.account.clone(),
                             sender: message.sender(),

--- a/src/components/main/compose/messages/mod.rs
+++ b/src/components/main/compose/messages/mod.rs
@@ -1,5 +1,11 @@
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
 use crate::{
     components::main::compose::{msg::Msg, reply::Reply},
+    iutils,
     state::{Actions, LastMsgSent},
     Account, Messaging, STATE,
 };
@@ -7,20 +13,43 @@ use dioxus::prelude::*;
 use dioxus_heroicons::{outline::Shape, Icon};
 
 use futures::StreamExt;
+use uuid::Uuid;
 use warp::{
     crypto::DID,
-    raygun::{Message, MessageEventKind, MessageOptions, RayGun, RayGunStream},
+    raygun::{Message, MessageEvent, MessageEventKind, MessageOptions, RayGun, RayGunStream},
 };
+
+#[derive(Eq, PartialEq)]
+enum TypingIndicator {
+    Typing,
+    NotTyping,
+}
+
+enum ChanCmd {
+    Indicator {
+        users_typing: UseRef<HashMap<DID, String>>,
+        current_chat: Option<Uuid>,
+        remote_id: DID,
+        remote_name: String,
+        indicator: TypingIndicator,
+    },
+    Timeout {
+        users_typing: UseRef<HashMap<DID, String>>,
+        current_chat: Option<Uuid>,
+    },
+}
 
 #[derive(Props, PartialEq)]
 pub struct Props {
     account: Account,
     messaging: Messaging,
+    users_typing: UseRef<HashMap<DID, String>>,
 }
 
 #[allow(non_snake_case)]
 pub fn Messages(cx: Scope<Props>) -> Element {
     log::debug!("rendering Messages");
+
     //Note: We will just unwrap for now though we need to
     //      handle the error properly if there is ever one when
     //      getting own identity
@@ -28,11 +57,13 @@ pub fn Messages(cx: Scope<Props>) -> Element {
 
     let mut rg = cx.props.messaging.clone();
     let ident = cx.props.account.read().get_own_identity().unwrap();
+    let my_did = ident.did_key().clone();
     // this one has a special name because of the other variable names within the use_future
     let list: UseRef<Vec<Message>> = use_ref(&cx, Vec::new).clone();
     // this one is for the rsx! macro. it is reversed for display purposes and defined here because `list` gets moved into the use_future
     let messages: Vec<Message> = list.read().iter().rev().cloned().collect();
 
+    // this is used for reading the event stream.
     let current_chat = state
         .read()
         .current_chat
@@ -49,86 +80,227 @@ pub fn Messages(cx: Scope<Props>) -> Element {
         }
     });
 
-    // restart the use_future when the current_chat changes
-    use_future(&cx, &current_chat, |current_chat| async move {
-        // don't stream messages from a nonexistent conversation
-        let mut current_chat = match current_chat {
-            // this better not panic
-            Some(c) => c,
-            None => return,
-        };
+    // keep track of who is typing by receiving events and adding timeouts
+    let chan = use_coroutine(&cx, |mut rx: UnboundedReceiver<ChanCmd>| async move {
+        // used for timeouts
+        let mut typing_times: HashMap<DID, Instant> = HashMap::new();
+        let mut prev_current_chat: Option<Uuid> = None;
 
-        if current_chat.num_unread_messages != 0 {
-            current_chat.num_unread_messages = 0;
-            state
-                .write_silent()
-                .dispatch(Actions::UpdateConversation(current_chat.clone()));
-        }
-
-        let mut stream = loop {
-            match rg
-                .get_conversation_stream(current_chat.conversation.id())
-                .await
-            {
-                Ok(stream) => break stream,
-                Err(e) => match &e {
-                    warp::error::Error::RayGunExtensionUnavailable => {
-                        //Give sometime for everything in the background to fully line up
-                        //Note, if this error still happens, it means there is an fatal error
-                        //      in the background
-                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-                    }
-                    _ => {
-                        // todo: properly report this error
-                        // eprintln!("failed to get_conversation_stream: {}", e);
-                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                    }
-                },
-            }
-        };
-        let messages = rg
-            .get_messages(current_chat.conversation.id(), MessageOptions::default())
-            .await
-            .unwrap_or_default();
-
-        //This is to prevent the future updating the state and causing a rerender
-        if *list.read() != messages {
-            log::debug!("updating messages list ");
-            *list.write() = messages;
-        }
-
-        while let Some(event) = stream.next().await {
-            match event {
-                MessageEventKind::MessageReceived {
-                    conversation_id,
-                    message_id,
-                }
-                | MessageEventKind::MessageSent {
-                    conversation_id,
-                    message_id,
+        while let Some(cmd) = rx.next().await {
+            match cmd {
+                ChanCmd::Indicator {
+                    users_typing,
+                    current_chat,
+                    remote_id,
+                    remote_name,
+                    indicator,
                 } => {
-                    if current_chat.conversation.id() == conversation_id {
-                        match rg.get_message(conversation_id, message_id).await {
-                            Ok(message) => {
-                                log::debug!("compose/messages streamed a new message ");
-                                list.write().push(message.clone());
-                                // todo: add message to chats sidebar
-                                current_chat.last_msg_sent =
-                                    Some(LastMsgSent::new(&message.value()));
-                                state
-                                    .write()
-                                    .dispatch(Actions::UpdateConversation(current_chat.clone()));
+                    if current_chat != prev_current_chat {
+                        typing_times.clear();
+                        prev_current_chat = current_chat;
+                    }
+                    if current_chat.is_some() {
+                        match indicator {
+                            TypingIndicator::Typing => {
+                                typing_times.insert(remote_id.clone(), Instant::now());
+                                if !users_typing.read().contains_key(&remote_id) {
+                                    users_typing.write().insert(remote_id, remote_name);
+                                }
                             }
-                            Err(_e) => {
-                                // todo: log error
+                            TypingIndicator::NotTyping => {
+                                typing_times.remove(&remote_id);
+                                if users_typing.read().contains_key(&remote_id) {
+                                    let _ = users_typing.write().remove(&remote_id);
+                                }
                             }
                         }
                     }
                 }
-                _ => {}
+                ChanCmd::Timeout {
+                    users_typing,
+                    current_chat,
+                } => {
+                    if current_chat != prev_current_chat {
+                        typing_times.clear();
+                        prev_current_chat = current_chat;
+                    }
+                    if current_chat.is_some() {
+                        let expired_indicators: HashMap<DID, Instant> = typing_times
+                            .iter()
+                            .filter(|(_k, v)| {
+                                let elapsed = Instant::now().duration_since(**v);
+                                elapsed > Duration::from_secs(3)
+                            })
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect();
+
+                        let new_users_typing: HashMap<DID, String> = users_typing
+                            .read()
+                            .iter()
+                            .filter(|(k, _v)| !expired_indicators.contains_key(k))
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect();
+
+                        for (k, _v) in expired_indicators {
+                            let _ = typing_times.remove(&k);
+                        }
+
+                        if new_users_typing != *users_typing.read() {
+                            *users_typing.write() = new_users_typing;
+                        }
+                    }
+                }
             }
         }
     });
+
+    // periodically check for timeouts
+    let chan1 = chan.clone();
+    let real_current_chat = state.read().current_chat.clone();
+    use_future(
+        &cx,
+        (&real_current_chat.clone(), &cx.props.users_typing.clone()),
+        |(current_chat, users_typing)| async move {
+            loop {
+                let _ = tokio::time::sleep(Duration::from_secs(3));
+                chan1.send(ChanCmd::Timeout {
+                    users_typing: users_typing.clone(),
+                    current_chat,
+                });
+            }
+        },
+    );
+
+    // handle message stream
+    let chan2 = chan.clone();
+    use_future(
+        &cx,
+        (
+            &current_chat,
+            &cx.props.users_typing.clone(),
+            &cx.props.account.clone(),
+        ),
+        |(current_chat, users_typing, mp)| async move {
+            // don't stream messages from a nonexistent conversation
+            let mut current_chat = match current_chat {
+                // this better not panic
+                Some(c) => c,
+                None => return,
+            };
+
+            if current_chat.num_unread_messages != 0 {
+                current_chat.num_unread_messages = 0;
+                state
+                    .write_silent()
+                    .dispatch(Actions::UpdateConversation(current_chat.clone()));
+            }
+
+            let mut stream = loop {
+                match rg
+                    .get_conversation_stream(current_chat.conversation.id())
+                    .await
+                {
+                    Ok(stream) => break stream,
+                    Err(e) => match &e {
+                        warp::error::Error::RayGunExtensionUnavailable => {
+                            //Give sometime for everything in the background to fully line up
+                            //Note, if this error still happens, it means there is an fatal error
+                            //      in the background
+                            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                        }
+                        _ => {
+                            // todo: properly report this error
+                            // eprintln!("failed to get_conversation_stream: {}", e);
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        }
+                    },
+                }
+            };
+
+            let messages = rg
+                .get_messages(current_chat.conversation.id(), MessageOptions::default())
+                .await
+                .unwrap_or_default();
+
+            //This is to prevent the future updating the state and causing a rerender
+            if *list.read() != messages {
+                log::debug!("updating messages list ");
+                *list.write() = messages;
+            }
+
+            while let Some(event) = stream.next().await {
+                match event {
+                    MessageEventKind::MessageReceived {
+                        conversation_id,
+                        message_id,
+                    }
+                    | MessageEventKind::MessageSent {
+                        conversation_id,
+                        message_id,
+                    } => {
+                        if current_chat.conversation.id() == conversation_id {
+                            match rg.get_message(conversation_id, message_id).await {
+                                Ok(message) => {
+                                    log::debug!("compose/messages streamed a new message ");
+                                    list.write().push(message.clone());
+                                    // todo: add message to chats sidebar
+                                    current_chat.last_msg_sent =
+                                        Some(LastMsgSent::new(&message.value()));
+                                    state.write().dispatch(Actions::UpdateConversation(
+                                        current_chat.clone(),
+                                    ));
+                                }
+                                Err(_e) => {
+                                    // todo: log error
+                                }
+                            }
+                        }
+                    }
+                    MessageEventKind::EventReceived {
+                        conversation_id,
+                        did_key,
+                        event,
+                    } => match event {
+                        MessageEvent::Typing => {
+                            if current_chat.conversation.id() == conversation_id
+                                && did_key != my_did
+                            {
+                                let username = iutils::get_username_from_did(did_key.clone(), &mp);
+                                chan2.send(ChanCmd::Indicator {
+                                    users_typing: users_typing.clone(),
+                                    current_chat: Some(conversation_id),
+                                    remote_id: did_key,
+                                    remote_name: username,
+                                    indicator: TypingIndicator::Typing,
+                                })
+                            }
+                        }
+                    },
+                    MessageEventKind::EventCancelled {
+                        conversation_id,
+                        did_key,
+                        event,
+                    } => match event {
+                        MessageEvent::Typing => {
+                            if current_chat.conversation.id() == conversation_id
+                                && did_key != my_did
+                            {
+                                let username = iutils::get_username_from_did(did_key.clone(), &mp);
+                                chan2.send(ChanCmd::Indicator {
+                                    users_typing: users_typing.clone(),
+                                    current_chat: Some(conversation_id),
+                                    remote_id: did_key,
+                                    remote_name: username,
+                                    indicator: TypingIndicator::NotTyping,
+                                })
+                            }
+                        }
+                    },
+                    _ => {}
+                }
+            }
+        },
+    );
 
     let rg = cx.props.messaging.clone();
     let senders: Vec<DID> = messages.iter().map(|msg| msg.sender()).collect();

--- a/src/components/main/compose/messages/mod.rs
+++ b/src/components/main/compose/messages/mod.rs
@@ -95,6 +95,7 @@ pub fn Messages(cx: Scope<Props>) -> Element {
                     remote_name,
                     indicator,
                 } => {
+                    log::debug!("received typing indicator");
                     if current_chat != prev_current_chat {
                         typing_times.clear();
                         prev_current_chat = current_chat;
@@ -120,6 +121,7 @@ pub fn Messages(cx: Scope<Props>) -> Element {
                     users_typing,
                     current_chat,
                 } => {
+                    log::debug!("received typing indicator timeout");
                     if current_chat != prev_current_chat {
                         typing_times.clear();
                         prev_current_chat = current_chat;
@@ -162,7 +164,8 @@ pub fn Messages(cx: Scope<Props>) -> Element {
         (&real_current_chat.clone(), &cx.props.users_typing.clone()),
         |(current_chat, users_typing)| async move {
             loop {
-                let _ = tokio::time::sleep(Duration::from_secs(4));
+                log::debug!("checking for typing indicator timeout on rx side");
+                tokio::time::sleep(Duration::from_secs(4)).await;
                 chan1.send(ChanCmd::Timeout {
                     users_typing: users_typing.clone(),
                     current_chat,

--- a/src/components/main/compose/mod.rs
+++ b/src/components/main/compose/mod.rs
@@ -4,10 +4,12 @@ pub mod reply;
 pub mod topbar;
 pub mod write;
 
+use std::collections::HashMap;
+
 use dioxus::prelude::*;
 use dioxus_heroicons::outline::Shape;
-use ui_kit::icon_button::IconButton;
-use warp::raygun::RayGun;
+use ui_kit::{icon_button::IconButton, typing_indicator::TypingIndicator};
+use warp::{crypto::DID, raygun::RayGun};
 
 use crate::{
     components::{
@@ -35,6 +37,7 @@ pub fn Compose(cx: Scope<Props>) -> Element {
     let text = use_state(&cx, String::new);
     let show_warning = use_state(&cx, || true);
     let show_media = use_state(&cx, || false);
+    let users_typing: &UseRef<HashMap<DID, String>> = use_ref(&cx, HashMap::new);
 
     cx.render(rsx! {
         div {
@@ -68,6 +71,7 @@ pub fn Compose(cx: Scope<Props>) -> Element {
                         Messages {
                             account: cx.props.account.clone(),
                             messaging: cx.props.messaging.clone(),
+                            users_typing: users_typing.clone(),
                         }
                     },
                     Write {
@@ -103,6 +107,9 @@ pub fn Compose(cx: Scope<Props>) -> Element {
                             }
                         },
                         on_upload: move |_| {}
+                    },
+                    TypingIndicator{
+                        users: users_typing.clone()
                     }
                 )
         }

--- a/src/components/main/compose/mod.rs
+++ b/src/components/main/compose/mod.rs
@@ -75,6 +75,7 @@ pub fn Compose(cx: Scope<Props>) -> Element {
                         }
                     },
                     Write {
+                        messaging: cx.props.messaging.clone(),
                         on_submit: move |message: String| {
                             text.set(String::from(""));
                             let mut rg = cx.props.messaging.clone();

--- a/src/components/main/compose/msg/mod.rs
+++ b/src/components/main/compose/msg/mod.rs
@@ -174,6 +174,9 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
                             },
                             TextArea {
                                 placeholder: l.send_a_reply.to_string(),
+                                on_input: move |e| {
+                                    todo!()
+                                }
                                 on_submit: move |e| {
                                     cx.props.on_reply.call(e);
 

--- a/src/components/main/compose/msg/mod.rs
+++ b/src/components/main/compose/msg/mod.rs
@@ -174,8 +174,8 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
                             },
                             TextArea {
                                 placeholder: l.send_a_reply.to_string(),
-                                on_input: move |e| {
-                                    todo!()
+                                on_input: move |_e| {
+                                   todo!("add typing indicator for message replies")
                                 }
                                 on_submit: move |e| {
                                     cx.props.on_reply.call(e);

--- a/src/components/main/compose/msg/mod.rs
+++ b/src/components/main/compose/msg/mod.rs
@@ -8,22 +8,23 @@ use ui_kit::{
     context_menu::{ContextItem, ContextMenu},
     icon_button::IconButton,
     profile_picture::PFP,
-    textarea::TextArea,
 };
 use warp::{crypto::DID, raygun::Message};
 
 use crate::{
+    iui_kit::textarea::TextArea,
     iutils::{
         self,
         get_meta::{get_meta, SiteMeta},
     },
-    Account, LANGUAGE,
+    Account, Messaging, LANGUAGE,
 };
 
 pub mod embeds;
 
 #[derive(Props)]
 pub struct Props<'a> {
+    messaging: Messaging,
     message: Message,
     account: Account,
     sender: DID,
@@ -173,10 +174,9 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
                                 on_pressed: move |_| {}
                             },
                             TextArea {
+                                messaging: cx.props.messaging.clone(),
                                 placeholder: l.send_a_reply.to_string(),
-                                on_input: move |_e| {
-                                   todo!("add typing indicator for message replies")
-                                }
+                                on_input: move |_| {}
                                 on_submit: move |e| {
                                     cx.props.on_reply.call(e);
 

--- a/src/components/main/compose/write/mod.rs
+++ b/src/components/main/compose/write/mod.rs
@@ -43,6 +43,9 @@ pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 },
             },
             TextArea {
+                on_input: move |e| {
+                    todo!()
+                }
                 on_submit: |val| cx.props.on_submit.call(val),
                 text: text.clone(),
                 placeholder: l.chatbar_placeholder.to_string()

--- a/src/components/main/compose/write/mod.rs
+++ b/src/components/main/compose/write/mod.rs
@@ -1,7 +1,10 @@
-use crate::{iutils::config::Config, LANGUAGE};
+use std::time::{Duration, Instant};
+
+use crate::{iutils::config::Config, Messaging, LANGUAGE, STATE};
 use audio_factory::AudioFactory;
 use dioxus::prelude::*;
 use dioxus_heroicons::outline::Shape;
+use futures::StreamExt;
 use ui_kit::{
     context_menu::{ContextItem, ContextMenu},
     icon_button::{self, IconButton},
@@ -9,19 +12,87 @@ use ui_kit::{
     textarea::TextArea,
 };
 use utils::extensions::BasicExtension;
+use uuid::Uuid;
+use warp::raygun::{MessageEvent, RayGunEvents};
 
 #[derive(Props)]
 pub struct Props<'a> {
+    messaging: Messaging,
     on_submit: EventHandler<'a, String>,
     on_upload: EventHandler<'a, ()>,
+}
+
+// the local side will send an event to indicate typing and refresh it periodically
+// the remote side will disable the typing indicator if a refresh isn't received in time
+// the remote side will also disable the typing indicator if a new message is received
+enum ChanCmd {
+    Typing { chat_id: Uuid, rg: Messaging },
+    NotTyping,
+    RefreshTyping { rg: Messaging },
 }
 
 #[allow(non_snake_case)]
 pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     log::debug!("rendering compose/Write");
     let config = Config::load_config_or_default();
+
+    let state = use_atom_ref(&cx, STATE);
+    let current_chat = state.read().current_chat;
     let text = use_state(&cx, String::new);
     let l = use_atom_ref(&cx, LANGUAGE).read();
+
+    // send typing indicators periodically
+    let chan = use_coroutine(&cx, |mut rx: UnboundedReceiver<ChanCmd>| async move {
+        // (conversation ID, time of last keystroke)
+        let mut typing_state: Option<(Uuid, Instant)> = None;
+
+        while let Some(cmd) = rx.next().await {
+            match cmd {
+                ChanCmd::Typing { chat_id, mut rg } => {
+                    let chat_id_changed = match typing_state {
+                        None => true,
+                        Some((prev_id, _)) => prev_id != chat_id,
+                    };
+
+                    typing_state = Some((chat_id, Instant::now()));
+
+                    if chat_id_changed {
+                        if let Err(_) = rg.send_event(chat_id, MessageEvent::Typing).await {
+                            // todo: log error
+                        }
+                    }
+                }
+                ChanCmd::NotTyping => {
+                    typing_state = None;
+                }
+                ChanCmd::RefreshTyping { mut rg } => {
+                    if let Some((chat_id, last_time)) = typing_state {
+                        let elapsed = Instant::now().duration_since(last_time);
+                        if elapsed > Duration::from_secs(3) {
+                            typing_state = None;
+                        } else {
+                            if let Err(_) = rg.send_event(chat_id, MessageEvent::Typing).await {
+                                // todo: log error
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // periodically re-send typing indicator
+    let chan1 = chan.clone();
+    use_future(&cx, &cx.props.messaging.clone(), |rg| async move {
+        loop {
+            // todo: start this wait when a user changes from not typing to typing
+            let _ = tokio::time::sleep(Duration::from_secs(3));
+            chan1.send(ChanCmd::RefreshTyping { rg: rg.clone() });
+        }
+    });
+
+    let chan2 = chan.clone();
+    let chan3 = chan.clone();
     cx.render(rsx! {
         div {
             class: "write",
@@ -43,10 +114,17 @@ pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 },
             },
             TextArea {
-                on_input: move |e| {
-                    todo!()
+                on_input: move |_e| {
+                    let chat_id = match current_chat {
+                        Some(c) => c,
+                        None => return
+                    };
+                    chan2.send(ChanCmd::Typing{chat_id, rg: cx.props.messaging.clone()});
                 }
-                on_submit: |val| cx.props.on_submit.call(val),
+                on_submit: move |val| {
+                    chan3.send(ChanCmd::NotTyping);
+                    cx.props.on_submit.call(val);
+                },
                 text: text.clone(),
                 placeholder: l.chatbar_placeholder.to_string()
             }

--- a/src/components/main/compose/write/mod.rs
+++ b/src/components/main/compose/write/mod.rs
@@ -80,7 +80,7 @@ pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             }
         }
     });
-
+    log::debug!("starting typing indicator timer");
     // periodically re-send typing indicator
     let chan1 = chan.clone();
     use_future(&cx, &cx.props.messaging.clone(), |rg| async move {
@@ -90,23 +90,23 @@ pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
             chan1.send(ChanCmd::RefreshTyping { rg: rg.clone() });
         }
     });
-
+    log::debug!("rendering write");
     let chan2 = chan.clone();
     let chan3 = chan.clone();
     cx.render(rsx! {
         div {
             class: "write",
             id: "write",
-            ContextMenu {
-                parent: String::from("write"),
-                items: cx.render(rsx! {
-                    ContextItem {
-                        onpressed: move |_| {},
-                        icon: Shape::Clipboard,
-                        text: String::from("Copy Conversation ID")
-                    },
-                })
-            },
+            //ContextMenu {
+            //    parent: String::from("write"),
+            //    items: cx.render(rsx! {
+            //        ContextItem {
+            //            onpressed: move |_| {},
+            //            icon: Shape::Clipboard,
+            //            text: String::from("Copy Conversation ID")
+            //        },
+            //    })
+            //},
             IconButton {
                 icon: Shape::Plus,
                 on_pressed: move |_| {

--- a/src/components/main/compose/write/mod.rs
+++ b/src/components/main/compose/write/mod.rs
@@ -1,19 +1,13 @@
-use std::time::{Duration, Instant};
-
-use crate::{iutils::config::Config, Messaging, LANGUAGE, STATE};
+use crate::{iui_kit::textarea::TextArea, iutils::config::Config, Messaging, LANGUAGE};
 use audio_factory::AudioFactory;
 use dioxus::prelude::*;
 use dioxus_heroicons::outline::Shape;
-use futures::StreamExt;
 use ui_kit::{
     context_menu::{ContextItem, ContextMenu},
     icon_button::{self, IconButton},
     small_extension_placeholder::SmallExtensionPlaceholder,
-    textarea::TextArea,
 };
 use utils::extensions::BasicExtension;
-use uuid::Uuid;
-use warp::raygun::{MessageEvent, RayGunEvents};
 
 #[derive(Props)]
 pub struct Props<'a> {
@@ -22,80 +16,14 @@ pub struct Props<'a> {
     on_upload: EventHandler<'a, ()>,
 }
 
-// the local side will send an event to indicate typing and refresh it periodically
-// the remote side will disable the typing indicator if a refresh isn't received in time
-// the remote side will also disable the typing indicator if a new message is received
-enum ChanCmd {
-    Typing { chat_id: Uuid, rg: Messaging },
-    NotTyping,
-    RefreshTyping { rg: Messaging },
-}
-
 #[allow(non_snake_case)]
 pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     log::debug!("rendering compose/Write");
     let config = Config::load_config_or_default();
 
-    let state = use_atom_ref(&cx, STATE);
-    let current_chat = state.read().current_chat;
     let text = use_state(&cx, String::new);
     let l = use_atom_ref(&cx, LANGUAGE).read();
 
-    // send typing indicators periodically
-    let chan = use_coroutine(&cx, |mut rx: UnboundedReceiver<ChanCmd>| async move {
-        // (conversation ID, time of last keystroke)
-        let mut typing_state: Option<(Uuid, Instant)> = None;
-
-        while let Some(cmd) = rx.next().await {
-            match cmd {
-                ChanCmd::Typing { chat_id, mut rg } => {
-                    log::debug!("typing indicator tx: received typing ");
-                    let chat_id_changed = match typing_state {
-                        None => true,
-                        Some((prev_id, _)) => prev_id != chat_id,
-                    };
-
-                    typing_state = Some((chat_id, Instant::now()));
-
-                    if chat_id_changed {
-                        if let Err(_) = rg.send_event(chat_id, MessageEvent::Typing).await {
-                            // todo: log error
-                        }
-                    }
-                }
-                ChanCmd::NotTyping => {
-                    log::debug!("typing indicator tx: received not typing ");
-                    typing_state = None;
-                }
-                ChanCmd::RefreshTyping { mut rg } => {
-                    log::debug!("typing indicator tx: received refresh typing ");
-                    if let Some((chat_id, last_time)) = typing_state {
-                        let elapsed = Instant::now().duration_since(last_time);
-                        if elapsed > Duration::from_secs(3) {
-                            typing_state = None;
-                        } else {
-                            if let Err(_) = rg.send_event(chat_id, MessageEvent::Typing).await {
-                                // todo: log error
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    });
-    log::debug!("starting typing indicator timer");
-    // periodically re-send typing indicator
-    let chan1 = chan.clone();
-    use_future(&cx, &cx.props.messaging.clone(), |rg| async move {
-        loop {
-            log::debug!("send typing indicator refresh");
-            tokio::time::sleep(Duration::from_secs(3)).await;
-            chan1.send(ChanCmd::RefreshTyping { rg: rg.clone() });
-        }
-    });
-    log::debug!("rendering write");
-    let chan2 = chan.clone();
-    let chan3 = chan.clone();
     cx.render(rsx! {
         div {
             class: "write",
@@ -117,17 +45,9 @@ pub fn Write<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 },
             },
             TextArea {
-                on_input: move |_e| {
-                    let chat_id = match current_chat {
-                        Some(c) => c,
-                        None => return
-                    };
-                    chan2.send(ChanCmd::Typing{chat_id, rg: cx.props.messaging.clone()});
-                }
-                on_submit: move |val| {
-                    chan3.send(ChanCmd::NotTyping);
-                    cx.props.on_submit.call(val);
-                },
+                messaging: cx.props.messaging.clone(),
+                on_input: move |_| {}
+                on_submit: move |val| cx.props.on_submit.call(val),
                 text: text.clone(),
                 placeholder: l.chatbar_placeholder.to_string()
             }

--- a/src/iui_kit/mod.rs
+++ b/src/iui_kit/mod.rs
@@ -1,0 +1,1 @@
+pub mod textarea;

--- a/src/iui_kit/textarea.rs
+++ b/src/iui_kit/textarea.rs
@@ -1,0 +1,109 @@
+use std::time::{Duration, Instant};
+
+use dioxus::prelude::*;
+use futures::StreamExt;
+use uuid::Uuid;
+use warp::raygun::{MessageEvent, RayGunEvents};
+
+use crate::{Messaging, STATE};
+
+// the local side will send an event to indicate typing and refresh it periodically
+// the remote side will disable the typing indicator if a refresh isn't received in time
+// the remote side will also disable the typing indicator if a new message is received
+enum ChanCmd {
+    Typing { chat_id: Uuid, rg: Messaging },
+    NotTyping,
+    RefreshTyping { rg: Messaging },
+}
+
+#[derive(Props)]
+pub struct Props<'a> {
+    messaging: Messaging,
+    on_input: EventHandler<'a, String>,
+    on_submit: EventHandler<'a, String>,
+    text: UseState<String>,
+    placeholder: String,
+}
+
+#[allow(non_snake_case)]
+#[allow(clippy::clone_double_ref)]
+#[allow(unused_assignments)]
+pub fn TextArea<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
+    log::debug!("rendering iui_kit/textarea");
+
+    let state = use_atom_ref(&cx, STATE);
+    let current_chat = state.read().current_chat;
+    // send typing indicators periodically
+    let chan = use_coroutine(&cx, |mut rx: UnboundedReceiver<ChanCmd>| async move {
+        // (conversation ID, time of last keystroke)
+        let mut typing_state: Option<(Uuid, Instant)> = None;
+
+        while let Some(cmd) = rx.next().await {
+            match cmd {
+                ChanCmd::Typing { chat_id, mut rg } => {
+                    log::debug!("typing indicator tx: received typing ");
+                    let chat_id_changed = match typing_state {
+                        None => true,
+                        Some((prev_id, _)) => prev_id != chat_id,
+                    };
+
+                    typing_state = Some((chat_id, Instant::now()));
+
+                    if chat_id_changed {
+                        if let Err(_) = rg.send_event(chat_id, MessageEvent::Typing).await {
+                            // todo: log error
+                        }
+                    }
+                }
+                ChanCmd::NotTyping => {
+                    log::debug!("typing indicator tx: received not typing ");
+                    typing_state = None;
+                }
+                ChanCmd::RefreshTyping { mut rg } => {
+                    log::debug!("typing indicator tx: received refresh typing ");
+                    if let Some((chat_id, last_time)) = typing_state {
+                        let elapsed = Instant::now().duration_since(last_time);
+                        if elapsed > Duration::from_secs(3) {
+                            typing_state = None;
+                        } else if let Err(_) = rg.send_event(chat_id, MessageEvent::Typing).await {
+                            // todo: log error
+                        }
+                    }
+                }
+            }
+        }
+    });
+    // periodically re-send typing indicator
+    let chan1 = chan.clone();
+    use_future(&cx, &cx.props.messaging.clone(), |rg| async move {
+        loop {
+            log::debug!("send typing indicator refresh");
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            chan1.send(ChanCmd::RefreshTyping { rg: rg.clone() });
+        }
+    });
+    let chan2 = chan.clone();
+    let chan3 = chan.clone();
+    cx.render(rsx!(ui_kit::textarea::TextArea {
+        on_input: move |val: String| {
+            let chat_id = match current_chat {
+                Some(c) => c,
+                None => {
+                    cx.props.on_input.call(val);
+                    return;
+                }
+            };
+            chan2.send(ChanCmd::Typing {
+                chat_id,
+                rg: cx.props.messaging.clone(),
+            });
+            cx.props.on_input.call(val);
+        },
+        on_submit: move |val: String| {
+            chan3.send(ChanCmd::NotTyping);
+            cx.props.on_submit.call(val);
+        },
+        text: cx.props.text.clone(),
+        placeholder: cx.props.placeholder.clone(),
+    }))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ use crate::components::main;
 use crate::components::prelude::{auth, loading, unlock};
 
 pub mod components;
+pub mod iui_kit;
 pub mod iutils;
 pub mod language;
 pub mod themes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::{
     sync::Arc,
     thread,
 };
+use tracing::metadata::LevelFilter;
 use tracing_subscriber::EnvFilter;
 use ui_kit::context_menu::{ContextItem, ContextMenu};
 use unic_langid::LanguageIdentifier;
@@ -145,7 +146,11 @@ fn main() {
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
     tracing_subscriber::fmt()
         .with_writer(non_blocking)
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::ERROR.into())
+                .from_env_lossy(),
+        )
         .init();
 
     if let Some(title) = opt.title {

--- a/src/ui_kit/Cargo.toml
+++ b/src/ui_kit/Cargo.toml
@@ -18,4 +18,4 @@ regex = "1.6.0"
 utils = { path = "../utils" }
 log = "0.4.17"
 
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb"}
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "e12cdd2c589286714142a7d892ab5b225ff41fc3"}

--- a/src/ui_kit/Cargo.toml
+++ b/src/ui_kit/Cargo.toml
@@ -18,4 +18,4 @@ regex = "1.6.0"
 utils = { path = "../utils" }
 log = "0.4.17"
 
-warp = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb"}

--- a/src/ui_kit/Cargo.toml
+++ b/src/ui_kit/Cargo.toml
@@ -18,4 +18,4 @@ regex = "1.6.0"
 utils = { path = "../utils" }
 log = "0.4.17"
 
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb"}
+warp = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }

--- a/src/ui_kit/src/lib.rs
+++ b/src/ui_kit/src/lib.rs
@@ -22,4 +22,5 @@ pub mod small_extension_placeholder;
 pub mod switch;
 pub mod textarea;
 pub mod tooltip;
+pub mod typing_indicator;
 pub mod utils;

--- a/src/ui_kit/src/textarea/mod.rs
+++ b/src/ui_kit/src/textarea/mod.rs
@@ -15,6 +15,7 @@ use dioxus_html::KeyCode;
 #[allow(unused_assignments)]
 pub fn TextArea<'a>(
     cx: Scope,
+    on_input: EventHandler<'a, String>,
     on_submit: EventHandler<'a, String>,
     text: UseState<String>,
     placeholder: String,
@@ -72,6 +73,7 @@ pub fn TextArea<'a>(
                 oninput: move |e| {
                     if !clearing_state.get() {
                         text.set(e.value.clone());
+                        on_input.call(e.value.clone());
                     } else {
                         clearing_state.set(false);
                     }

--- a/src/ui_kit/src/typing_indicator/mod.rs
+++ b/src/ui_kit/src/typing_indicator/mod.rs
@@ -1,20 +1,19 @@
+use std::collections::HashMap;
+
 use dioxus::prelude::*;
+use warp::crypto::DID;
 
-#[derive(PartialEq, Eq, Props)]
-pub struct Props {
-    users: Vec<String>,
-}
-
+#[inline_props]
 #[allow(non_snake_case)]
-pub fn TypingIndicator(cx: Scope<Props>) -> Element {
-    let users_list = cx.props.users.clone();
+pub fn TypingIndicator(cx: Scope, users: UseRef<HashMap<DID, String>>) -> Element {
+    let users_list: Vec<String> = users.read().iter().map(|(_k, v)| v.clone()).collect();
     let name_typing = if users_list.len() <= 3 {
         users_list.join(", ")
     } else {
         users_list.len().to_string() + " users"
     };
     let article = if users_list.is_empty() {
-        String::from("Why do i see this indicator? None is")
+        return None;
     } else if users_list.len() == 1 {
         String::from(" is")
     } else {

--- a/src/ui_kit/src/typing_indicator/mod.rs
+++ b/src/ui_kit/src/typing_indicator/mod.rs
@@ -1,0 +1,40 @@
+use dioxus::prelude::*;
+
+#[derive(PartialEq, Eq, Props)]
+pub struct Props {
+    users: Vec<String>,
+}
+
+#[allow(non_snake_case)]
+pub fn TypingIndicator(cx: Scope<Props>) -> Element {
+    let users_list = cx.props.users.clone();
+    let name_typing = if users_list.len() <= 3 {
+        users_list.join(", ")
+    } else {
+        users_list.len().to_string() + " users"
+    };
+    let article = if users_list.is_empty() {
+        String::from("Why do i see this indicator? None is")
+    } else if users_list.len() == 1 {
+        String::from(" is")
+    } else {
+        String::from(" are")
+    };
+
+    cx.render(rsx! {
+        div {
+            class:"typing-indicator",
+            div {
+                class: "loader",
+            }
+            div {
+                class: "primary",
+                "{name_typing}"
+            }
+            div {
+                class: "secondary",
+                "{article} typing..."
+            }
+        }
+    })
+}

--- a/src/ui_kit/src/typing_indicator/mod.rs
+++ b/src/ui_kit/src/typing_indicator/mod.rs
@@ -6,6 +6,8 @@ use warp::crypto::DID;
 #[inline_props]
 #[allow(non_snake_case)]
 pub fn TypingIndicator(cx: Scope, users: UseRef<HashMap<DID, String>>) -> Element {
+    log::debug!("rendering typing indicator");
+
     let users_list: Vec<String> = users.read().iter().map(|(_k, v)| v.clone()).collect();
     let name_typing = if users_list.len() <= 3 {
         users_list.join(", ")

--- a/src/ui_kit/src/typing_indicator/styles.scss
+++ b/src/ui_kit/src/typing_indicator/styles.scss
@@ -1,0 +1,49 @@
+.typing-indicator {
+  width: 100%;
+  padding: 0 20px 10px 20px;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  color: var(--theme-text-bright);
+  .loader {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    margin-right: 32px;
+    position: relative;
+    flex-shrink: 0;
+    animation: typing 1s linear infinite alternate;
+  }
+  .primary {
+    height: 20px;
+    padding-right: 4px;
+    font-weight: bold;
+    word-break: break-all;
+    overflow: hidden;
+    box-sizing: border-box;
+    text-transform: capitalize;
+  }
+  .secondary {
+    height: 20px;
+    flex-shrink: 0;
+    word-wrap: nowrap;
+  }
+}
+
+@keyframes typing {
+  0% {
+    background: rgba(255, 255, 255, 1);
+    box-shadow: 10px 0px 0px 0px rgba(255, 255, 255, 0.2),
+      20px 0px 0px 0px rgba(255, 255, 255, 0.2);
+  }
+  50% {
+    background: rgba(255, 255, 255, 0.4);
+    box-shadow: 10px 0px 0px 0px rgba(255, 255, 255, 2),
+      20px 0px 0px 0px rgba(255, 255, 255, 0.2);
+  }
+  100% {
+    background: rgba(255, 255, 255, 0.4);
+    box-shadow: 10px 0px 0px 0px rgba(255, 255, 255, 0.2),
+      20px 0px 0px 0px rgba(255, 255, 255, 1);
+  }
+}

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 soloud = "1.0.2"
 notify-rust = "4.5.10"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb"}
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "e12cdd2c589286714142a7d892ab5b225ff41fc3"}
 dioxus = { version = "0.2.4", features = ["desktop", "router", "fermi"] }
 libloading = "0.7.3"
 once_cell = "1.13"

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 soloud = "1.0.2"
 notify-rust = "4.5.10"
-warp = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb"}
+warp = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }
 dioxus = { version = "0.2.4", features = ["desktop", "router", "fermi"] }
 libloading = "0.7.3"
 once_cell = "1.13"

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 soloud = "1.0.2"
 notify-rust = "4.5.10"
-warp = { git = "https://github.com/Satellite-im/Warp", branch="warp/rg-send-events" }
+warp = { git = "https://github.com/Satellite-im/Warp", rev = "335313d98faf58f753971019183d3137a46cb3fb"}
 dioxus = { version = "0.2.4", features = ["desktop", "router", "fermi"] }
 libloading = "0.7.3"
 once_cell = "1.13"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- This PR adds a typing indicator to Uplink
- a newer version of warp is required for this
- The typing indicator times out, ensuring that if the remote side loses internet connectivity, the local side won't continue to display the typing indicator
- the remote side periodically sends events to refresh the typing indicator, preventing the time out
- the timing needs to be tweaked to make the timing indicator disappear sooner
- needs testing of multiple users - the typing indicator should display different messages depending on how many users are simultaneously typing. it should also send the typing indicator to everyone in the group (currently just tested with a 2-person conversation)

### Which issue(s) this PR fixes 🔨
- Resolve #
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

