### PR TITLE
fix(friends): reconfigure styling for friends-separator

### DIFF
--- a/src/components/main/friends/styles.scss
+++ b/src/components/main/friends/styles.scss
@@ -26,9 +26,7 @@
 
       .friends-separator {
         align-items: center;
-        height: 12px;
-        width: calc(100% - 5rem);
-        margin: 4px 0px 16px 0px;
+        padding: 0.25rem 0;
         text-align: left;
       }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Improves the css for the friends separator (the single letters above the user list items) while maintaining the same styling

Before:
<img width="1062" alt="スクリーンショット 2022-11-28 16 08 23" src="https://user-images.githubusercontent.com/40599535/204199582-8159c474-7439-4936-bb1f-77fd21e4a370.png">

After (should look the same):
<img width="1062" alt="スクリーンショット 2022-11-28 16 09 04" src="https://user-images.githubusercontent.com/40599535/204199706-b9a849de-b952-429e-88e3-e1cbd9363e03.png">


### Which issue(s) this PR fixes 🔨
- Resolve #435 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
For more info:
[PR #441](https://github.com/Satellite-im/Uplink/pull/411#discussion_r1032374305)