### PR TITLE
fix(sidebar): add ellipsis to username

### DIFF
--- a/src/components/main/sidebar/chat/styles.scss
+++ b/src/components/main/sidebar/chat/styles.scss
@@ -63,6 +63,7 @@
       flex: 1;
       flex-direction: column;
       text-align: left;
+      overflow: hidden;
 
       .top-row {
         display: inline-flex;
@@ -70,6 +71,9 @@
 
         h3 {
           margin: 0;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
 
         .timestamp {

--- a/src/components/reusable/toolbar/styles.scss
+++ b/src/components/reusable/toolbar/styles.scss
@@ -4,15 +4,17 @@
   padding: 1rem;
   width: 100%;
   flex-direction: row;
-  // border-bottom: 1px solid var(--theme-borders);
 
   #content {
     flex: 1;
     line-height: 1;
     display: inline-flex;
+    overflow: hidden;
+
     .pfp {
       margin-right: 0.5rem;
     }
+
     .activity.inline {
       margin-top: 0.5rem;
     }
@@ -23,6 +25,7 @@
     height: 100%;
     max-width: fit-content;
     display: inline-flex;
+
     .icon-button {
       margin-left: 0.25rem;
       padding: 0 0.25rem;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Adds ellipsis to usernames in chat sidebar
- Adds ellipsis to usernames in chat toolbar

Before:
<img width="1062" alt="スクリーンショット 2022-11-29 12 36 54" src="https://user-images.githubusercontent.com/40599535/204417808-93ffd364-19a6-4e85-af32-35d7ea38406f.png">

After:
<img width="1062" alt="スクリーンショット 2022-11-29 12 37 56" src="https://user-images.githubusercontent.com/40599535/204417827-4973dda2-af2a-4741-a298-2fbe3819678a.png">

### Which issue(s) this PR fixes 🔨
- Resolve #308 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->