### PR TITLE
fix(msg): adjust background style of reply modal

### DIFF
--- a/src/components/main/compose/msg/styles.scss
+++ b/src/components/main/compose/msg/styles.scss
@@ -153,7 +153,7 @@
     bottom: 0;
     display: inline-flex;
     justify-content: center;
-    left: 330px;
+    left: var(--sidebar-width);
     overflow: hidden;
     position: fixed;
     right: 0;

--- a/src/components/main/styles.scss
+++ b/src/components/main/styles.scss
@@ -45,6 +45,10 @@
       height: 100%;
       position: absolute;
     }
+
+    .popout-mask {
+      left: 0;
+    }
   }
 
   #files,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Fixes the background width and position for reply modal for desktop and mobile views

Before:
![スクリーンショット 2022-11-29 14 54 23](https://user-images.githubusercontent.com/40599535/204435850-ca7a88ab-fd71-4f70-a946-19546b550f42.png)
![スクリーンショット 2022-11-29 14 54 35](https://user-images.githubusercontent.com/40599535/204435862-9e3633cc-d611-42d1-9135-7093b2630071.png)

After:
![スクリーンショット 2022-11-29 14 53 15](https://user-images.githubusercontent.com/40599535/204435807-6d2d8537-77f8-4d1b-b6ab-8e851c0769dd.png)
![スクリーンショット 2022-11-29 14 53 23](https://user-images.githubusercontent.com/40599535/204435817-cd9f6693-05b5-45fb-aca3-25d968ebd316.png)


### Which issue(s) this PR fixes 🔨
- Resolve #319 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->