### PR TITLE
chore(ci): make windows build in github actions

### DIFF
--- a/.github/workflows/add-conflicts-label.yml
+++ b/.github/workflows/add-conflicts-label.yml
@@ -1,15 +1,15 @@
-name: Add Conflicts Label
-on:
-  push:
-    branches:
-      - dev
-jobs:
-  triage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mschilde/auto-label-merge-conflicts@master
-        with:
-          CONFLICT_LABEL_NAME: 'missing fixing conflict'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAX_RETRIES: 5
-          WAIT_MS: 5000
+# name: Add Conflicts Label
+# on:
+#   push:
+#     branches:
+#       - dev
+# jobs:
+#   triage:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: mschilde/auto-label-merge-conflicts@master
+#         with:
+#           CONFLICT_LABEL_NAME: 'missing fixing conflict'
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           MAX_RETRIES: 5
+#           WAIT_MS: 5000

--- a/.github/workflows/add-label.yml
+++ b/.github/workflows/add-label.yml
@@ -1,17 +1,17 @@
-name: Add Label
-on:
-  pull_request:
-    types:
-      - opened
-jobs:
-  add-label:
-    name: Add Label
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: christianvuerings/add-labels@v1
-        with:
-          labels: |
-            missing dev review
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# name: Add Label
+# on:
+#   pull_request:
+#     types:
+#       - opened
+# jobs:
+#   add-label:
+#     name: Add Label
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: christianvuerings/add-labels@v1
+#         with:
+#           labels: |
+#             missing dev review
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -38,8 +38,19 @@ jobs:
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-          MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
+          MACOS_KEYCHAIN_NAME: ${{ MACOS_KEYCHAIN_NAME }}
         run: |
+          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+          security delete-keychain builduplink.keychain 
+          rm /Library/Keychains/builduplink.keychain
+          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+          security default-keychain -s builduplink.keychain
+          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+          security set-keychain-settings builduplink.keychain
+          security import certificate.p12 -k builduplink.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+          security find-identity -p codesigning -v
+          security list-keychains
           make dmg-universal
       - name: "Notarize executable"
         env:

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -40,9 +40,6 @@ jobs:
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
           MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
         run: |
-          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" "/Library/Keychains/$MACOS_KEYCHAIN_NAME"
-          security set-keychain-settings "/Library/Keychains/$MACOS_KEYCHAIN_NAME"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" "/Library/Keychains/$MACOS_KEYCHAIN_NAME"
           make dmg-universal
       - name: "Notarize executable"
         env:

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
           security delete-keychain builduplink.keychain 
-          rm /Library/Keychains/builduplink.keychain
+          rm ~/Library/Keychains/builduplink.keychain-db
           security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
           security default-keychain -s builduplink.keychain
           security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -41,8 +41,6 @@ jobs:
           MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
         run: |
           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security delete-keychain builduplink.keychain 
-          rm ~/Library/Keychains/builduplink.keychain-db
           security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
           security default-keychain -s builduplink.keychain
           security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -38,7 +38,7 @@ jobs:
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-          MACOS_KEYCHAIN_NAME: ${{ MACOS_KEYCHAIN_NAME }}
+          MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
         run: |
           security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" "$HOME/Library/Keychains/$MACOS_KEYCHAIN_NAME"
           security set-keychain-settings "~/Library/Keychains/$MACOS_KEYCHAIN_NAME"

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -40,11 +40,6 @@ jobs:
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
           MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
         run: |
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
-          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
-          security import ./certificate.p12 -k builduplink.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
           make dmg-universal
       - name: "Notarize executable"
         env:

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -40,6 +40,11 @@ jobs:
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
           MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
         run: |
+          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+          security import ./certificate.p12 -k builduplink.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
           make dmg-universal
       - name: "Notarize executable"
         env:

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -38,7 +38,7 @@ jobs:
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-          MACOS_KEYCHAIN_NAME: ${{ MACOS_KEYCHAIN_NAME }}
+          MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
         run: |
           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
           security delete-keychain builduplink.keychain 

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -1,82 +1,85 @@
-# https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
-# notarization info from here^
-name: Make dmg
+# # https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
+# # notarization info from here^
+# name: Make dmg
 
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited]
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# # Watch for tags being created, after self hosted runner setup we can change this back, or make it when a user manually requests a dmg
+# on:
+#   push:
+#     tags:
+#       - '*' 
 
-jobs:
-  build_sign_macos:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      - name: Install Protobuf
-        continue-on-error: true
-        run: |
-          brew update
-          brew install protobuf 
-          brew install cmake rustup-init gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav gst-rtsp-server gst-editing-services
-      - name: Add Targets
-        env:
-          MACOSX_DEPLOYMENT_TARGET: "10.13"
-        run: |
-          rustup target add x86_64-apple-darwin aarch64-apple-darwin
-      - name: Codesign and Build executable
-        continue-on-error: true
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-          MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
-          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-          MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
-        run: |
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
-          security default-keychain -s builduplink.keychain
-          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
-          security set-keychain-settings builduplink.keychain
-          security import certificate.p12 -k builduplink.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
-          security find-identity -p codesigning -v
-          security list-keychains
-          make dmg-universal
-      - name: "Notarize executable"
-        env:
-          PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
-          PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
-          PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.MACOS_NOTARIZATION_PWD }}
-          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-        run: |
-          echo "Create keychain profile"
-          xcrun notarytool store-credentials "uplink-notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
-          echo "Creating temp notarization archive"
-          ditto -c -k --keepParent "target/release/macos/Uplink.app" "notarization.zip"
-          echo "Notarize app"
-          xcrun notarytool submit "notarization.zip" --keychain-profile "uplink-notarytool-profile" --wait
-          echo "Attach staple"
-          xcrun stapler staple "target/release/macos/Uplink.app"
-      - name: Create ZIP archive
-        run: |
-          ditto -c -k --sequesterRsrc --keepParent target/release/macos/Uplink.app Uplink-Mac-Universal.zip
-      - name: Calculate hashes
-        run: |
-          shasum -a 256 Uplink-Mac-Universal.zip > Uplink-Mac-Universal.zip.sha256.txt
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v3
-        env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
-        with:
-          name: Uplink Universal Mac App
-          path: |
-            Uplink-Mac-Universal.zip
-            Uplink-Mac-Universal.zip.sha256.txt
+# env:
+#   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# jobs:
+#   build_sign_macos:
+#     runs-on: macos-latest
+#     steps:
+#       - name: Checkout Repo
+#         uses: actions/checkout@v3
+#       - name: Install Rust
+#         uses: actions-rs/toolchain@v1
+#         with:
+#           toolchain: stable
+#           override: true
+#           components: rustfmt, clippy
+#       - name: Install Protobuf
+#         continue-on-error: true
+#         run: |
+#           brew update
+#           brew install protobuf 
+#           brew install cmake rustup-init gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav gst-rtsp-server gst-editing-services
+#       - name: Add Targets
+#         env:
+#           MACOSX_DEPLOYMENT_TARGET: "10.13"
+#         run: |
+#           rustup target add x86_64-apple-darwin aarch64-apple-darwin
+#       - name: Codesign and Build executable
+#         continue-on-error: true
+#         env:
+#           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+#           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+#           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+#           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+#           MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
+#         run: |
+#           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+#           security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+#           security default-keychain -s builduplink.keychain
+#           security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+#           security set-keychain-settings builduplink.keychain
+#           security import certificate.p12 -k builduplink.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+#           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+#           security find-identity -p codesigning -v
+#           security list-keychains
+#           make dmg-universal
+#       - name: "Notarize executable"
+#         env:
+#           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.MACOS_NOTARIZATION_APPLE_ID }}
+#           PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
+#           PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.MACOS_NOTARIZATION_PWD }}
+#           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+#         run: |
+#           echo "Create keychain profile"
+#           xcrun notarytool store-credentials "uplink-notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
+#           echo "Creating temp notarization archive"
+#           ditto -c -k --keepParent "target/release/macos/Uplink.app" "notarization.zip"
+#           echo "Notarize app"
+#           xcrun notarytool submit "notarization.zip" --keychain-profile "uplink-notarytool-profile" --wait
+#           echo "Attach staple"
+#           xcrun stapler staple "target/release/macos/Uplink.app"
+#       - name: Create ZIP archive
+#         run: |
+#           ditto -c -k --sequesterRsrc --keepParent target/release/macos/Uplink.app Uplink-Mac-Universal.zip
+#       - name: Calculate hashes
+#         run: |
+#           shasum -a 256 Uplink-Mac-Universal.zip > Uplink-Mac-Universal.zip.sha256.txt
+#       - name: Upload Artifact
+#         uses: actions/upload-artifact@v3
+#         env:
+#           NODE_OPTIONS: "--max-old-space-size=8192"
+#         with:
+#           name: Uplink Universal Mac App
+#           path: |
+#             Uplink-Mac-Universal.zip
+#             Uplink-Mac-Universal.zip.sha256.txt

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build_sign_macos:
-    runs-on: self-hosted
+    runs-on: macos-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -2,18 +2,15 @@
 # notarization info from here^
 name: Make dmg
 
-# Watch for tags being created, after self hosted runner setup we can change this back, or make it when a user manually requests a dmg
 on:
-  push:
-    tags:
-      - '*' 
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  CARGO_TERM_COLOR: always
 
 jobs:
   build_sign_macos:
-    runs-on: macos-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -27,26 +24,32 @@ jobs:
         continue-on-error: true
         run: |
           brew update
-          brew install protobuf
+          brew install protobuf 
+          brew install cmake rustup-init gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav gst-rtsp-server gst-editing-services
       - name: Add Targets
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
         run: |
           rustup target add x86_64-apple-darwin aarch64-apple-darwin
       - name: Codesign and Build executable
+        continue-on-error: true
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+          MACOS_KEYCHAIN_NAME: ${{ MACOS_KEYCHAIN_NAME }}
         run: |
           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain 
-          security default-keychain -s builduplink.keychain
-          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
-          security set-keychain-settings builduplink.keychain
-          security import certificate.p12 -k builduplink.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+          ## security delete-keychain "~/Library/Keychains/builduplink.keychain-db"
+          ## security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" "~/Library/Keychains/builduplink.keychain-db"
+          ## security default-keychain -s "~/Library/Keychains/builduplink.keychain-db"
+          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" "$HOME/Library/Keychains/$MACOS_KEYCHAIN_NAME"
+          security set-keychain-settings "~/Library/Keychains/$MACOS_KEYCHAIN_NAME"
+          ## security import certificate.p12 -k "~/Library/Keychains/builduplink.keychain-db" -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" "~/Library/Keychains/$MACOS_KEYCHAIN_NAME"
+          ## security find-identity -p codesigning -v
+          ## security list-keychains
           make dmg-universal
       - name: "Notarize executable"
         env:

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -40,9 +40,9 @@ jobs:
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
           MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
         run: |
-          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" "$HOME/Library/Keychains/$MACOS_KEYCHAIN_NAME"
-          security set-keychain-settings "~/Library/Keychains/$MACOS_KEYCHAIN_NAME"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" "~/Library/Keychains/$MACOS_KEYCHAIN_NAME"
+          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" "/Library/Keychains/$MACOS_KEYCHAIN_NAME"
+          security set-keychain-settings "/Library/Keychains/$MACOS_KEYCHAIN_NAME"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" "/Library/Keychains/$MACOS_KEYCHAIN_NAME"
           make dmg-universal
       - name: "Notarize executable"
         env:

--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -40,16 +40,9 @@ jobs:
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
           MACOS_KEYCHAIN_NAME: ${{ MACOS_KEYCHAIN_NAME }}
         run: |
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          ## security delete-keychain "~/Library/Keychains/builduplink.keychain-db"
-          ## security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" "~/Library/Keychains/builduplink.keychain-db"
-          ## security default-keychain -s "~/Library/Keychains/builduplink.keychain-db"
           security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" "$HOME/Library/Keychains/$MACOS_KEYCHAIN_NAME"
           security set-keychain-settings "~/Library/Keychains/$MACOS_KEYCHAIN_NAME"
-          ## security import certificate.p12 -k "~/Library/Keychains/builduplink.keychain-db" -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" "~/Library/Keychains/$MACOS_KEYCHAIN_NAME"
-          ## security find-identity -p codesigning -v
-          ## security list-keychains
           make dmg-universal
       - name: "Notarize executable"
         env:

--- a/.github/workflows/ci-make-windows.yml
+++ b/.github/workflows/ci-make-windows.yml
@@ -1,0 +1,38 @@
+# # https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
+# ## TODO: Once we get the EV certificate, make this code-sign the windows exe so we dont have that nasty error message
+# name: Make Windows Executable
+
+# on:
+#   pull_request:
+#     types: [opened, synchronize, reopened, edited]
+# env:
+#   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# jobs:
+#   windows:
+#     runs-on: windows-latest
+#     defaults:
+#       run:
+#         shell: bash
+#     steps:
+#       - uses: actions/checkout@v3
+#       - name: Install Rust
+#         uses: actions-rs/toolchain@v1
+#         with:
+#           toolchain: stable
+#           override: true
+#           components: rustfmt, clippy
+#       - name: Setup cmake
+#         uses: jwlawson/actions-setup-cmake@v1.13
+#       - name: Use cmake
+#         run: cmake --version
+#       - name: Install Protoc
+#         uses: arduino/setup-protoc@v1
+#       - name: Build resources
+#         run: cargo build
+#       - name: Upload Artifact
+#         uses: actions/upload-artifact@v3
+#         with:
+#           name: Uplink-Windows.zip
+#           path: |
+#             target/debug/uplink.exe

--- a/.github/workflows/ci-make-windows.yml
+++ b/.github/workflows/ci-make-windows.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: Uplink-Windows.zip
+          name: Uplink-Windows
           path: |
             target/debug/uplink.exe

--- a/.github/workflows/ci-make-windows.yml
+++ b/.github/workflows/ci-make-windows.yml
@@ -1,38 +1,38 @@
-# # https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
-# ## TODO: Once we get the EV certificate, make this code-sign the windows exe so we dont have that nasty error message
-# name: Make Windows Executable
+# https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
+## TODO: Once we get the EV certificate, make this code-sign the windows exe so we dont have that nasty error message
+name: Make Windows Executable
 
-# on:
-#   pull_request:
-#     types: [opened, synchronize, reopened, edited]
-# env:
-#   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-# jobs:
-#   windows:
-#     runs-on: windows-latest
-#     defaults:
-#       run:
-#         shell: bash
-#     steps:
-#       - uses: actions/checkout@v3
-#       - name: Install Rust
-#         uses: actions-rs/toolchain@v1
-#         with:
-#           toolchain: stable
-#           override: true
-#           components: rustfmt, clippy
-#       - name: Setup cmake
-#         uses: jwlawson/actions-setup-cmake@v1.13
-#       - name: Use cmake
-#         run: cmake --version
-#       - name: Install Protoc
-#         uses: arduino/setup-protoc@v1
-#       - name: Build resources
-#         run: cargo build
-#       - name: Upload Artifact
-#         uses: actions/upload-artifact@v3
-#         with:
-#           name: Uplink-Windows.zip
-#           path: |
-#             target/debug/uplink.exe
+jobs:
+  windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+      - name: Use cmake
+        run: cmake --version
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+      - name: Build resources
+        run: cargo build
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Uplink-Windows.zip
+          path: |
+            target/debug/uplink.exe

--- a/.github/workflows/comment-PR-dmg.yml
+++ b/.github/workflows/comment-PR-dmg.yml
@@ -1,54 +1,60 @@
-name: Comment on pull request with dmg file
-on:
-  workflow_run:
-    workflows: ['Make dmg']
-    types: [completed]
-jobs:
-  pr_comment:
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v5
-        with:
-          # This snippet is public-domain, taken from
-          # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
-          script: |
-            async function upsertComment(owner, repo, issue_number, purpose, body) {
-              const {data: comments} = await github.rest.issues.listComments(
-                {owner, repo, issue_number});
-              const marker = `<!-- bot: ${purpose} -->`;
-              body = marker + "\n" + body;
-              const existing = comments.filter((c) => c.body.includes(marker));
-              if (existing.length > 0) {
-                const last = existing[existing.length - 1];
-                core.info(`Updating comment ${last.id}`);
-                await github.rest.issues.updateComment({
-                  owner, repo,
-                  body,
-                  comment_id: last.id,
-                });
-              } else {
-                core.info(`Creating a comment in issue / PR #${issue_number}`);
-                await github.rest.issues.createComment({issue_number, body, owner, repo});
-              }
-            }
-            const {owner, repo} = context.repo;
-            const run_id = ${{github.event.workflow_run.id}};
-            const pull_requests = ${{ toJSON(github.event.workflow_run.pull_requests) }};
-            if (!pull_requests.length) {
-              return core.error("This workflow doesn't match any pull requests!");
-            }
-            const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
-            if (!artifacts.length) {
-              return core.error(`No artifacts found`);
-            }
-            let body = `Download the .dmg for this pull request:\n`;
-            for (const art of artifacts) {
-              body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
-            }
-            core.info("Review thread message body:", body);
-            for (const pr of pull_requests) {
-              await upsertComment(owner, repo, pr.number,
-                "nightly-link", body);
-            }
+## Commenting this out until we can get it working with all builds
+# name: Comment on PR with Artifacts
+# on:
+#   workflow_run:
+#     workflows: ["Make MacOS Bundle", "Make Windows Executable"]
+#     types: [completed]
+# jobs:
+#   pr_comment:
+#     if: |
+#       github.event.workflow_run.event == 'pull_request' &&
+#       github.event.workflow_run.conclusion == 'success' &&
+#       (github.event.workflow_run.name == 'Make MacOS Bundle' || github.event.workflow_run.name == 'Make Windows Executable')
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/github-script@v5
+#         with:
+#           # This snippet is public-domain, taken from
+#           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
+#           script: |
+#             core.info(`Working on ${JSON.parse(github.event.workflow_run)}`);
+#             async function upsertComment(owner, repo, issue_number, purpose, body) {
+#               const {data: comments} = await github.rest.issues.listComments(
+#                 {owner, repo, issue_number});
+#               const marker = `<!-- bot: ${purpose} -->`;
+#               body = marker + "\n" + body;
+#               const existing = comments.filter((c) => c.body.includes(marker));
+#               if (existing.length > 0) {
+#                 const last = existing[existing.length - 1];
+#                 core.info(`Updating comment ${last.id}`);
+#                 await github.rest.issues.updateComment({
+#                   owner, repo,
+#                   body,
+#                   comment_id: last.id,
+#                 });
+#               } else {
+#                 core.info(`Creating a comment in issue / PR #${issue_number}`);
+#                 await github.rest.issues.createComment({issue_number, body, owner, repo});
+#               }
+#             }
+
+#             const {owner, repo} = context.repo;
+#             const run_id = ${{github.event.workflow_run.id}};
+#             const pull_requests = ${{ toJSON(github.event.workflow_run.pull_requests) }};
+#             if (!pull_requests.length) {
+#               return core.error("This workflow doesn't match any pull requests!");
+#             }
+#             const artifacts = await github.paginate(
+#               github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
+#             if (!artifacts.length) {
+#               return core.error(`No artifacts found`);
+#             }
+#             let body = `Universal Mac Appt:\n`;
+#             for (const art of artifacts) {
+#               body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+#             }
+#             core.info("Review thread message body:", body);
+#             for (const pr of pull_requests) {
+#               await upsertComment(owner, repo, pr.number,
+#                 "nightly-link", body);
+#             }

--- a/.github/workflows/fix-typos.yml
+++ b/.github/workflows/fix-typos.yml
@@ -1,19 +1,19 @@
-name: Automatically fix typos
-on:
-  push:
-    branches:
-      - dev
+# name: Automatically fix typos
+# on:
+#   push:
+#     branches:
+#       - dev
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: dev
-      - uses: sobolevn/misspell-fixer-action@master
-      - uses: peter-evans/create-pull-request@v4.2.0
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+# jobs:
+#   build:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#         with:
+#           ref: dev
+#       - uses: sobolevn/misspell-fixer-action@master
+#       - uses: peter-evans/create-pull-request@v4.2.0
+#         env:
+#           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+#         with:
+#           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-issue.yml
+++ b/.github/workflows/link-issue.yml
@@ -1,13 +1,13 @@
-name: "Issue Links"
-on:
-  pull_request:
-    types: [opened]
+# name: "Issue Links"
+# on:
+#   pull_request:
+#     types: [opened]
 
-jobs:
-  issue-links:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: tkt-actions/add-issue-links@v1.8.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          branch-prefix: "issue-"
+# jobs:
+#   issue-links:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: tkt-actions/add-issue-links@v1.8.0
+#         with:
+#           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+#           branch-prefix: "issue-"

--- a/.github/workflows/lint-PR-title.yml
+++ b/.github/workflows/lint-PR-title.yml
@@ -1,35 +1,35 @@
-name: Lint Pull Request Title
+# name: Lint Pull Request Title
 
-on:
-  pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
+# on:
+#   pull_request:
+#     types:
+#       - opened
+#       - edited
+#       - reopened
 
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+# jobs:
+#   lint:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
 
-      - uses: actions-ecosystem/action-regex-match@v2
-        id: regex-match
-        with:
-          text: ${{ github.event.pull_request.title }}
-          regex: '(?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|add|update|task|chore|test)\([a-z-A-Z-0-9]+\):\s.+'
+#       - uses: actions-ecosystem/action-regex-match@v2
+#         id: regex-match
+#         with:
+#           text: ${{ github.event.pull_request.title }}
+#           regex: '(?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|add|update|task|chore|test)\([a-z-A-Z-0-9]+\):\s.+'
 
-      - uses: actions-ecosystem/action-create-comment@v1
-        if: ${{ steps.regex-match.outputs.match == '' }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            :warning: The title of this PR is invalid.
-            Please make the title match this format `<type>(<scope>): <description>`.
-            e.g.) 
-            `add(cli): enable --verbose flag`
-            `fix(api): avoid unexpected error in handler`
+#       - uses: actions-ecosystem/action-create-comment@v1
+#         if: ${{ steps.regex-match.outputs.match == '' }}
+#         with:
+#           github_token: ${{ secrets.GITHUB_TOKEN }}
+#           body: |
+#             :warning: The title of this PR is invalid.
+#             Please make the title match this format `<type>(<scope>): <description>`.
+#             e.g.) 
+#             `add(cli): enable --verbose flag`
+#             `fix(api): avoid unexpected error in handler`
 
-            allowed types - add, update, task, chore, feat, test, fix
-      - run: exit 1
-        if: ${{ steps.regex-match.outputs.match == '' }}
+#             allowed types - add, update, task, chore, feat, test, fix
+#       - run: exit 1
+#         if: ${{ steps.regex-match.outputs.match == '' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,56 +1,56 @@
-on: [pull_request]
+# on: [pull_request]
 
-name: Continuous integration
+# name: Continuous integration
 
-jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install Packages
-        run: sudo apt-get update && sudo apt-get -y install libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev protobuf-compiler libasound2-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+# jobs:
+#   check:
+#     name: Check
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: actions-rs/toolchain@v1
+#         with:
+#           profile: minimal
+#           toolchain: stable
+#           override: true
+#       - name: Install Packages
+#         run: sudo apt-get update && sudo apt-get -y install libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev protobuf-compiler libasound2-dev
+#       - uses: actions-rs/cargo@v1
+#         with:
+#           command: check
 
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install Packages
-        run: sudo apt-get update && sudo apt-get -y install libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev protobuf-compiler libasound2-dev
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+#   fmt:
+#     name: Rustfmt
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: actions-rs/toolchain@v1
+#         with:
+#           profile: minimal
+#           toolchain: stable
+#           override: true
+#       - name: Install Packages
+#         run: sudo apt-get update && sudo apt-get -y install libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev protobuf-compiler libasound2-dev
+#       - run: rustup component add rustfmt
+#       - uses: actions-rs/cargo@v1
+#         with:
+#           command: fmt
+#           args: --all -- --check
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install Packages
-        run: sudo apt-get update && sudo apt-get -y install libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev protobuf-compiler libasound2-dev
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+#   clippy:
+#     name: Clippy
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: actions-rs/toolchain@v1
+#         with:
+#           profile: minimal
+#           toolchain: stable
+#           override: true
+#       - name: Install Packages
+#         run: sudo apt-get update && sudo apt-get -y install libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev protobuf-compiler libasound2-dev
+#       - run: rustup component add clippy
+#       - uses: actions-rs/cargo@v1
+#         with:
+#           command: clippy
+#           args: -- -D warnings

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -1,14 +1,14 @@
-name: Remove All Labels
+# name: Remove All Labels
 
-on:
-  pull_request:
-    types: [closed]
+# on:
+#   pull_request:
+#     types: [closed]
 
-jobs:
-  remove_labels:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: rogerluan/label-remover@v1.0.1
-        with:
-          github_token: ${{ secrets.github_token }}
+# jobs:
+#   remove_labels:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: rogerluan/label-remover@v1.0.1
+#         with:
+#           github_token: ${{ secrets.github_token }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,12 +1,12 @@
-name: Security audit
-on:
-  schedule:
-    - cron: "0 0 * * *"
-jobs:
-  audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+# name: Security audit
+# on:
+#   schedule:
+#     - cron: "0 0 * * *"
+# jobs:
+#   audit:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: actions-rs/audit-check@v1
+#         with:
+#           token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,7 @@ struct Opt {
     #[clap(long)]
     experimental_node: bool,
 }
+#![windows_subsystem = "windows"]
 
 fn main() {
     if fdlimit::raise_fd_limit().is_none() {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+// Hide the console window on linux if not cargo run
+#![cfg_attr(not(run), windows_subsystem = "windows")]
+
 use crate::iutils::config::Config;
 use ::utils::Account;
 use clap::Parser;
@@ -50,8 +53,6 @@ mod state;
 static TOAST_MANAGER: AtomRef<ToastManager> = |_| ToastManager::default();
 static LANGUAGE: AtomRef<Language> = |_| Language::by_locale(AvailableLanguages::EnUS);
 
-
-
 static DEFAULT_PATH: Lazy<RwLock<PathBuf>> =
     Lazy::new(|| RwLock::new(dirs::home_dir().unwrap_or_default().join(".warp")));
 pub const WINDOW_SUFFIX_NAME: &str = "Uplink";
@@ -60,18 +61,22 @@ static DEFAULT_WINDOW_NAME: Lazy<RwLock<String>> =
     Lazy::new(|| RwLock::new(String::from(WINDOW_SUFFIX_NAME)));
 static STATE: AtomRef<PersistedState> = |_| PersistedState::load_or_initial();
 
-static DROPPED_FILE: Lazy<RwLock<DroppedFile>> =
-    Lazy::new(|| RwLock::new(DroppedFile {files_local_path: Vec::new(), file_drag_event: FileDragEvent::None}));       
+static DROPPED_FILE: Lazy<RwLock<DroppedFile>> = Lazy::new(|| {
+    RwLock::new(DroppedFile {
+        files_local_path: Vec::new(),
+        file_drag_event: FileDragEvent::None,
+    })
+});
 
 #[derive(PartialEq, Clone)]
 pub enum FileDragEvent {
     Dropped,
-    None, 
+    None,
 }
 
 #[derive(Clone)]
 pub struct DroppedFile {
-    files_local_path: Vec<String>, 
+    files_local_path: Vec<String>,
     file_drag_event: FileDragEvent,
 }
 
@@ -84,8 +89,6 @@ pub struct State {
 }
 #[derive(Debug, Parser)]
 #[clap(name = "")]
-#![cfg_attr(not(test), windows_subsystem = "windows")]
-
 struct Opt {
     #[clap(long)]
     path: Option<PathBuf>,
@@ -199,7 +202,6 @@ fn main() {
         .with_inner_size(LogicalSize::new(950.0, 600.0))
         .with_min_inner_size(LogicalSize::new(330.0, 500.0));
 
-
     #[cfg(target_os = "macos")]
     dioxus::desktop::launch_with_props(
         App,
@@ -215,18 +217,21 @@ fn main() {
                 let mut dropped_file_local_path = format!("{:?}", e);
                 let file_drag_event = if dropped_file_local_path.contains("Dropped") {
                     FileDragEvent::Dropped
-                 } else {
-                    FileDragEvent::None 
+                } else {
+                    FileDragEvent::None
                 };
-               
-                dropped_file_local_path = 
-                dropped_file_local_path.replace("Dropped([", "")
-                .replace("Hovered([", "")
-                .replace("])", "")
-                .replace('"', "");
-                let files_path: Vec<String> = dropped_file_local_path.split(",").map(|file_path| String::from(file_path)).collect();
+
+                dropped_file_local_path = dropped_file_local_path
+                    .replace("Dropped([", "")
+                    .replace("Hovered([", "")
+                    .replace("])", "")
+                    .replace('"', "");
+                let files_path: Vec<String> = dropped_file_local_path
+                    .split(",")
+                    .map(|file_path| String::from(file_path))
+                    .collect();
                 *DROPPED_FILE.write() = DroppedFile {
-                    files_local_path: files_path, 
+                    files_local_path: files_path,
                     file_drag_event: file_drag_event,
                 };
                 true
@@ -282,7 +287,7 @@ fn App(cx: Scope<State>) -> Element {
     //TODO: Display an error instead of panicing
     std::fs::create_dir_all(DEFAULT_PATH.read().clone()).expect("Error creating directory");
     Config::new_file();
- 
+
     cx.use_hook(|_| {
         cx.provide_context(cx.props.messaging.clone());
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,8 @@ pub struct State {
 }
 #[derive(Debug, Parser)]
 #[clap(name = "")]
+#![cfg_attr(not(test), windows_subsystem = "windows")]
+
 struct Opt {
     #[clap(long)]
     path: Option<PathBuf>,
@@ -92,7 +94,6 @@ struct Opt {
     #[clap(long)]
     experimental_node: bool,
 }
-#![windows_subsystem = "windows"]
 
 fn main() {
     if fdlimit::raise_fd_limit().is_none() {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
This slightly changes the mac universal app creation and adds windows builds. This does not sign the windows app or notarize it, so users have to click through a warning prompt to be able to run the .exe

We are still waiting for Comodo to getback to us about our signing cert to add that to the build step.

I disabled the 'comment on PR' action because it was set up to only run with the mac DMG, and am working on something improved to replace it/attach a note with links. 

To access files now, click the github action in the bottom of the issue, go to summary, and scroll to the bottom where artifacts are.

### Which issue(s) this PR fixes 🔨
- Resolve #458
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

