### PR TITLE
fix(files-usage): remodel usage bar for files

### DIFF
--- a/src/components/main/files/toolbar/mod.rs
+++ b/src/components/main/files/toolbar/mod.rs
@@ -39,7 +39,7 @@ pub fn Toolbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                 }
             }),
             div {
-                class: "usage-container",
+                id: "files-toolbar-content",
                 div {
                     class: "mobile-back-button",
                     Button {
@@ -50,13 +50,16 @@ pub fn Toolbar<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                         },
                     },
                 },
-                Usage {
-                    usage: UsageStats {
-                        available: 1256,
-                        total: 123456,
-                        used: 122200,
-                        percent_free: 75,
-                    }
+                div {
+                    class: "usage-container",
+                    Usage {
+                        usage: UsageStats {
+                            available: 1256,
+                            total: 123456,
+                            used: 122200,
+                            percent_free: 75,
+                        }
+                    },
                 },
             },
         },

--- a/src/components/main/files/toolbar/styles.scss
+++ b/src/components/main/files/toolbar/styles.scss
@@ -1,3 +1,13 @@
-.usage-container {
+#files-toolbar-content {
   display: flex;
+  min-width: 0;
+  width: 100%;
+  gap: 16px;
+
+  .usage-container {
+    display: flex;
+    padding-right: 16px;
+    min-width: 0;
+    flex-grow: 1;
+  }
 }

--- a/src/components/main/files/toolbar/usage/mod.rs
+++ b/src/components/main/files/toolbar/usage/mod.rs
@@ -3,6 +3,28 @@ use humansize::format_size;
 use humansize::DECIMAL;
 
 #[derive(Props, PartialEq, Eq)]
+pub struct UsageContentProps {
+    space: String,
+    available: u128,
+}
+
+#[allow(non_snake_case)]
+pub fn UsageContent(cx: Scope<UsageContentProps>) -> Element {
+    cx.render(rsx! {
+        Fragment {
+            div {
+                class: "usage_bar_heading ellipsis",
+                "{cx.props.available} Free",
+            }
+            div {
+                class: "usage_bar_subheading ellipsis",
+                "Disk Space: {cx.props.space}"
+            }
+        }
+    })
+}
+
+#[derive(Props, PartialEq, Eq)]
 pub struct Props {
     usage: UsageStats,
 }
@@ -31,37 +53,24 @@ pub fn Usage(cx: Scope<Props>) -> Element {
         format_size(free_space, DECIMAL),
         format_size(total_space, DECIMAL)
     );
-    let space_clone = space.clone();
 
     cx.render(rsx! {
         div {
             id: "usage",
             div {
-                id: "usage_bar",
-                style: "width:{perc}%;",
-                (perc > 60.0).then(||  rsx!{
-                    span {
-                        class: "usage-available-text",
-                        "{cx.props.usage.available} Free",
-                        br {},
-                        span {
-                            "Disk Space: {space}"
-                        }
-                    }
-                })
+                id: "usage_bar_bg",
+                UsageContent {
+                    space: space.clone(),
+                    available: cx.props.usage.available.clone()
+                }
             },
             div {
-                id: "usage_bar_bg",
-                (perc <= 59.0).then(||  rsx!{
-                    span {
-                        class: "usage-available-text",
-                        "{cx.props.usage.available} Free",
-                        br {},
-                        span {
-                            "Disk Space: {space_clone}"
-                        }
-                    }
-                })
+                id: "usage_bar",
+                style: "-webkit-clip-path: inset(0 0 0 {perc}%);",
+                UsageContent {
+                    space: space.clone(),
+                    available: cx.props.usage.available.clone()
+                }
             },
         },
     })

--- a/src/components/main/files/toolbar/usage/styles.scss
+++ b/src/components/main/files/toolbar/usage/styles.scss
@@ -1,55 +1,46 @@
 #usage {
-  width: calc(100% - 1rem);
-  border-radius: 50%;
-  border-bottom: none;
-  position: relative;
-  display: inline-flex;
-  height: 40px;
   border-radius: 20px;
+  position: relative;
+  display: flex;
   overflow: hidden;
-  // padding: 0rem 1rem;
+  line-height: 1;
+  flex-grow: 1;
 
   #usage_bar,
   #usage_bar_bg {
-    background: var(--theme-primary);
-    height: 100%;
-    border-radius: 2px;
-    position: absolute;
-    z-index: 1;
-    padding-left: 0.5rem;
-    border-radius: 20px;
-    display: inline-flex;
+    display: flex;
     justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    padding: 0.4rem 1rem;
+    overflow: hidden;
+    border-radius: 20px;
+
+    .usage_bar_heading,
+    .usage_bar_subheading {
+      width: 100%;
+      text-align: center;
+    }
+
+    .usage_bar_subheading {
+      font-size: var(--text-small);
+    }
   }
+
   #usage_bar_bg {
+    flex-grow: 1;
+    background: var(--theme-primary);
+    color: var(--theme-text);
+  }
+
+  #usage_bar {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    transition: clip-path 1s ease-in-out;
     background: var(--theme-background-light);
-    width: 100%;
-    z-index: 0;
-    padding-right: 0.5rem;
-  }
-  #usage_text {
-    margin-top: 16px;
-    padding: 0.1rem;
     color: var(--theme-text-muted);
-    text-align: right;
-  }
-}
-
-.usage-available-text {
-  display: inline-flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  color: var(--theme-text);
-  text-align: center;
-
-  span {
-    font-size: var(--text-small);
-    color: var(--theme-text-muted);
-  }
-}
-
-#usage_bar_bg {
-  .usage-available-text {
   }
 }

--- a/src/components/main/styles.scss
+++ b/src/components/main/styles.scss
@@ -93,8 +93,4 @@
   .show-on-desktop {
     display: none;
   }
-
-  #usage {
-    padding: 0rem 1rem;
-  }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Rewrites the disk usage bar for files as previous model was not compatible with necessary styling features, including dynamic color for text.

Before:
<img width="700" alt="Screen Shot 2022-11-29 at 9 23 55 AM" src="https://user-images.githubusercontent.com/2993032/204592293-a0bcb9e6-fb99-438f-a964-aee5e2bea297.png">

After:
<img width="674" alt="スクリーンショット 2022-11-30 13 04 56" src="https://user-images.githubusercontent.com/40599535/204689769-2bfa2718-b249-475d-8dc7-0bf808c6938e.png">

### Which issue(s) this PR fixes 🔨
- Resolve #365 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Additional comments 🎤
- As the scope of the below issue is slightly different it will be handled in a separate PR.
#370 
