### PR TITLE
fix(msg): display attachments in reply modal

### DIFF
--- a/src/components/main/compose/msg/attachment/styles.scss
+++ b/src/components/main/compose/msg/attachment/styles.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   overflow: hidden;
   border-radius: 4px;
+  width: 100%;
 
   .embed-icon {
     min-width: 40px;

--- a/src/components/main/compose/msg/mod.rs
+++ b/src/components/main/compose/msg/mod.rs
@@ -5,8 +5,8 @@ use linkify::LinkFinder;
 use pulldown_cmark::{html, Options, Parser};
 
 use ui_kit::{
-    context_menu::{ContextItem, ContextMenu},
     button::Button,
+    context_menu::{ContextItem, ContextMenu},
     profile_picture::PFP,
 };
 use warp::{crypto::DID, raygun::Message};
@@ -69,6 +69,7 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
         Some(Err(_)) => SiteMeta::default(),
         None => SiteMeta::default(),
     };
+    let meta2 = meta.clone();
 
     let popout = use_state(&cx, || false);
     // text has been lifted from the child components into Msg so that
@@ -142,6 +143,7 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
             message: cx.props.message.clone(),
         })
     });
+    let attachment_list2 = attachment_list.clone();
 
     cx.render(rsx! (
         div {
@@ -172,7 +174,16 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
                             div {
                                 class: "value popout {first} {middle} {last}",
                                 div {
-                                    dangerous_inner_html: "{output1}"
+                                    class: "message-content",
+                                    dangerous_inner_html: "{output1}",
+                                    has_links.then(|| rsx!{
+                                        LinkEmbed {
+                                            meta: meta2
+                                        }
+                                    }),
+                                    div {
+                                        attachment_list2
+                                    }
                                 },
                             },
                         }

--- a/src/components/main/compose/msg/styles.scss
+++ b/src/components/main/compose/msg/styles.scss
@@ -87,6 +87,10 @@
         p {
           margin: 0.25rem 0;
         }
+
+        .message-content {
+          width: 100%;
+        }
       }
 
       p {
@@ -171,8 +175,8 @@
       display: inline-flex;
       flex-direction: column;
       position: absolute;
-      width: max-content;
       z-index: 3;
+      padding: 8px;
 
       .controls,
       .user-message {
@@ -194,7 +198,7 @@
 
       .value {
         border-radius: 16px 16px 16px 4px;
-        max-width: 250px;
+        max-width: 280px;
         text-align: left;
         word-break: break-all;
       }

--- a/src/ui_kit/src/button/mod.rs
+++ b/src/ui_kit/src/button/mod.rs
@@ -58,7 +58,7 @@ pub fn Button<'a>(cx: Scope<'a, Props>) -> Element<'a> {
 
     cx.render(rsx! {
         button {
-            class: "{class}",
+            class: "{class} ellipsis",
             disabled: "{disabled}",
             onclick: move |evt| cx.props.on_pressed.call(evt),
             cx.render(match cx.props.icon {
@@ -69,7 +69,10 @@ pub fn Button<'a>(cx: Scope<'a, Props>) -> Element<'a> {
                 },
                 None => rsx! {Fragment()},
             }),
-            "{text}"
+            div {
+                class: "button-text ellipsis",
+                "{text}"
+            }
         }
     })
 }

--- a/src/ui_kit/src/button/styles.scss
+++ b/src/ui_kit/src/button/styles.scss
@@ -25,6 +25,10 @@
     padding: 0;
     min-width: 40px;
 
+    .button-text {
+      display: none;
+    }
+
     &.button-lg {
       min-width: 52px;
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Displays message attachments in the reply modal as they were previously not being added.

### Which issue(s) this PR fixes 🔨
- Resolve #446 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->