### PR TITLE
feat(state): persist hide prerelease message

### DIFF
--- a/src/components/main/compose/mod.rs
+++ b/src/components/main/compose/mod.rs
@@ -36,9 +36,9 @@ pub fn Compose(cx: Scope<Props>) -> Element {
     let state = use_atom_ref(&cx, STATE);
     let current_chat = state.read().current_chat;
     let l = use_atom_ref(&cx, LANGUAGE).read();
-    let warningMessage = l.prerelease_warning.to_string();
+    let warning_message = l.prerelease_warning.to_string();
     let text = use_state(&cx, String::new);
-    let show_warning = use_state(&cx, || true);
+    let show_warning = use_state(&cx, || state.read().show_prerelease_notice);
     let show_media = use_state(&cx, || false);
     let users_typing: &UseRef<HashMap<DID, String>> = use_ref(&cx, HashMap::new);
 
@@ -65,10 +65,11 @@ pub fn Compose(cx: Scope<Props>) -> Element {
                     (**show_warning).then(|| rsx!(
                         div {
                             class: "alpha-warning animate__animated animate__slideInDown",
-                            "{warningMessage}",
+                            "{warning_message}",
                             Button {
                                 on_pressed: move |_| {
                                     show_warning.set(false);
+                                    state.write().dispatch(Actions::SetShowPrerelaseNotice(false));
                                 },
                                 icon: Shape::Check,
                             }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -124,6 +124,7 @@ impl PersistedState {
                     .cloned()
                     .collect();
                 state.all_chats = new_chats;
+                state.total_unreads = total_notifications(&state);
             }
             Actions::ClearChat => {
                 state.current_chat = None;
@@ -132,8 +133,8 @@ impl PersistedState {
                 state.current_chat = Some(info.conversation.id());
             }
             Actions::UpdateConversation(info) => {
-                state.total_unreads = total_notifications(&state);
                 state.all_chats.insert(info.conversation.id(), info);
+                state.total_unreads = total_notifications(&state);
             }
             Actions::UpdateFavorites(favorites) => {
                 state.favorites = favorites;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -22,7 +22,7 @@ pub enum Actions {
 }
 
 /// tracks the active conversations. Chagnes are persisted
-#[derive(Serialize, Deserialize, Default, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Default, Eq, PartialEq)]
 pub struct PersistedState {
     /// the currently selected conversation
     pub current_chat: Option<Uuid>,
@@ -114,36 +114,35 @@ impl PersistedState {
     }
 
     pub fn dispatch(&mut self, action: Actions) {
-        let mut state: PersistedState = self.clone();
         match action {
             Actions::AddRemoveConversations(new_chats) => {
-                state.favorites = self
+                self.favorites = self
                     .favorites
                     .iter()
                     .filter(|id| new_chats.contains_key(id))
                     .cloned()
                     .collect();
-                state.all_chats = new_chats;
-                state.total_unreads = total_notifications(&state);
+                self.all_chats = new_chats;
+                self.total_unreads = total_notifications(&self);
             }
             Actions::ClearChat => {
-                state.current_chat = None;
+                self.current_chat = None;
             }
             Actions::ChatWith(info) => {
-                state.current_chat = Some(info.conversation.id());
+                self.current_chat = Some(info.conversation.id());
             }
             Actions::UpdateConversation(info) => {
-                state.all_chats.insert(info.conversation.id(), info);
-                state.total_unreads = total_notifications(&state);
+                self.all_chats.insert(info.conversation.id(), info);
+                self.total_unreads = total_notifications(&self);
             }
             Actions::UpdateFavorites(favorites) => {
-                state.favorites = favorites;
+                self.favorites = favorites;
             }
             Actions::HideSidebar(slide_bar_bool) => {
-                state.hide_sidebar = slide_bar_bool;
+                self.hide_sidebar = slide_bar_bool;
             }
             Actions::SetShowPrerelaseNotice(value) => {
-                state.show_prerelease_notice = value;
+                self.show_prerelease_notice = value;
             } // Actions::SendNotification(title, content, sound) => {
               //     let _ = PushNotification(title, content, sound);
               //     PersistedState {
@@ -155,11 +154,7 @@ impl PersistedState {
               //     }
               // }
         };
-        // only save while there's a lock on PersistedState
-        state.save();
-
-        // modify PersistedState via assignment rather than mutation
-        *self = state;
+        self.save();
     }
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -17,6 +17,7 @@ pub enum Actions {
     UpdateFavorites(HashSet<Uuid>),
     HideSidebar(bool),
     ClearChat,
+    SetShowPrerelaseNotice(bool),
     // SendNotification(String, String, Sounds),
 }
 
@@ -33,6 +34,7 @@ pub struct PersistedState {
     // show sidebar boolean, used with in mobile view
     pub hide_sidebar: bool,
     pub total_unreads: u32,
+    pub show_prerelease_notice: bool,
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Eq, PartialEq)]
@@ -93,6 +95,7 @@ impl PersistedState {
             Ok(b) => serde_json::from_slice::<PersistedState>(&b).unwrap_or_default(),
             Err(_) => {
                 let mut state: PersistedState = Default::default();
+                state.show_prerelease_notice = true;
                 state
             }
         }
@@ -138,30 +141,18 @@ impl PersistedState {
             Actions::HideSidebar(slide_bar_bool) => {
                 state.hide_sidebar = slide_bar_bool;
             }
-            Actions::UpdateFavorites(favorites) => PersistedState {
-                current_chat: self.current_chat,
-                all_chats: self.all_chats.clone(),
-                favorites,
-                hide_sidebar: self.hide_sidebar,
-                total_unreads: self.total_unreads,
-            },
-            Actions::HideSidebar(slide_bar_bool) => PersistedState {
-                current_chat: self.current_chat,
-                all_chats: self.all_chats.clone(),
-                favorites: self.favorites.clone(),
-                hide_sidebar: slide_bar_bool,
-                total_unreads: self.total_unreads,
-            },
-            // Actions::SendNotification(title, content, sound) => {
-            //     let _ = PushNotification(title, content, sound);
-            //     PersistedState {
-            //         current_chat: self.current_chat,
-            //         all_chats: self.all_chats.clone(),
-            //         favorites: self.favorites.clone(),
-            //         hide_sidebar: self.hide_sidebar,
-            //         total_unreads: total_notifications(&self),
-            //     }
-            // }
+            Actions::SetShowPrerelaseNotice(value) => {
+                state.show_prerelease_notice = value;
+            } // Actions::SendNotification(title, content, sound) => {
+              //     let _ = PushNotification(title, content, sound);
+              //     PersistedState {
+              //         current_chat: self.current_chat,
+              //         all_chats: self.all_chats.clone(),
+              //         favorites: self.favorites.clone(),
+              //         hide_sidebar: self.hide_sidebar,
+              //         total_unreads: total_notifications(&self),
+              //     }
+              // }
         };
         // only save while there's a lock on PersistedState
         state.save();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Refactor `state/mod.rs` dispatch fn to use mut clone of PersistedState to simplify logic
- Add `show_prerelease_notice` field to PersistedState
- Use persisted state to conditionally show prerelease notice in chat

### Which issue(s) this PR fixes 🔨
- Resolve #383 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

