### PR TITLE
feat(chat): show attachment preview and click to show original message

### DIFF
--- a/src/components/main/compose/messages/mod.rs
+++ b/src/components/main/compose/messages/mod.rs
@@ -367,7 +367,9 @@ pub fn Messages(cx: Scope<Props>) -> Element {
                                             rsx!{
                                                 Reply {
                                                     // key: "{message_id}-reply",
+                                                    message_id: message.id(),
                                                     message: message.value().join("\n"),
+                                                    attachments_len: message.attachments().len(),
                                                     is_remote: is_remote,
                                                     account: cx.props.account.clone(),
                                                     sender: message.sender(),

--- a/src/components/main/compose/reply/mod.rs
+++ b/src/components/main/compose/reply/mod.rs
@@ -1,4 +1,5 @@
 use dioxus::prelude::*;
+use uuid::Uuid;
 use warp::crypto::DID;
 
 use crate::iutils;
@@ -7,10 +8,12 @@ use ui_kit::profile_picture::PFP;
 
 #[derive(Props, PartialEq)]
 pub struct Props {
+    message_id: Uuid,
     message: String,
     is_remote: bool,
     account: Account,
     sender: DID,
+    attachments_len: usize,
 }
 
 #[allow(non_snake_case)]
@@ -58,9 +61,41 @@ pub fn Reply(cx: Scope<Props>) -> Element {
                         size: ui_kit::profile_picture::Size::Normal
                     })
                 }
-                p {
-                    "{cx.props.message}",
-                },
+                div {
+                    class: "reply-message-container",
+                    onclick: move |e| {
+                        use_eval(&cx)(format!("
+                            document.getElementById('{}-message').scrollIntoView({{
+                                behavior: 'smooth',
+                                block: 'start'
+                            }})
+                        ", cx.props.message_id));
+                    },
+                    if cx.props.attachments_len > 0 {
+                        rsx!(div {
+                            class: "reply-attachments",
+                            match cx.props.attachments_len {
+                                1 => rsx!(span {
+                                    class: "reply-attachments-count",
+                                    "1 attachment"
+                                }),
+                                _ => rsx!(span {
+                                    class: "reply-attachments-count",
+                                    "{cx.props.attachments_len} attachments"
+                                })
+                            }
+                        })
+                    } else {
+                        rsx!(Fragment {})
+                    }
+                    if cx.props.message.len() > 0 {
+                        rsx!(p {
+                            "{cx.props.message}",
+                        })
+                    } else {
+                        rsx!(Fragment {})
+                    }
+                }
                 if cx.props.is_remote {
                     rsx!(PFP {
                         src: profile_picture,

--- a/src/components/main/compose/reply/styles.scss
+++ b/src/components/main/compose/reply/styles.scss
@@ -9,6 +9,17 @@
     align-self: flex-start;
     align-items: center;
 
+    .reply-message-container {
+      display: flex;
+      gap: 0.25rem;
+      flex-direction: column;
+      cursor: pointer;
+    }
+
+    .reply-attachments {
+      color: var(--theme-text-muted);
+    }
+
     p {
       background: var(--theme-background-light);
       padding: 0.5rem;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Show attachment preview for replies to messages with attachments
- Hide empty chat bubble if text length is 0
- Add click to scroll to original message

### Which issue(s) this PR fixes 🔨
- Resolve #471
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

