### PR TITLE
update(Friends): auto-delete text after searching/adding a friend

### DIFF
--- a/src/components/main/friends/sidebar/mod.rs
+++ b/src/components/main/friends/sidebar/mod.rs
@@ -4,14 +4,10 @@ use crate::{
 };
 
 use arboard::Clipboard;
-use dioxus::{
-    core::UiEvent,
-    events::{FormEvent, MouseData},
-    prelude::*,
-};
+use dioxus::{core::UiEvent, events::MouseData, prelude::*};
 use dioxus_heroicons::outline::Shape;
 use dioxus_toast::{Position, ToastInfo};
-use ui_kit::{button::Button, input::Input};
+use ui_kit::{button::Button, input_add_friend::InputAddFriend};
 
 use std::{collections::HashSet, time::Duration};
 use warp::crypto::DID;
@@ -154,16 +150,14 @@ pub fn FindFriends(cx: Scope, account: Account, add_error: UseState<String>) -> 
             "{l.add_someone}",
         },
         div {
-            class: "add",
-            Input {
-                placeholder: l.add_placeholder.clone(),
-                icon: Shape::UserPlus,
-                on_change: move |evt: FormEvent| {
-                    add_error.set(String::new());
-                    remote_friend.set(evt.value.clone());
-                },
-                on_enter: move |_| {
-                        let did = DID::try_from(format!("did:key:{}", remote_friend.clone()));
+            class: "add",  
+            InputAddFriend{
+                    // TODO:add placeholder
+                    // placeholder: l.add_placeholder.clone(),
+                    value: remote_friend.clone(),
+                    on_change: move |_| add_error.set(String::new()),
+                    on_enter: move |_| {
+                    let did = DID::try_from(format!("did:key:{}", remote_friend.clone()));
                     match did {
                         Ok(d) => {
                             match account.clone()
@@ -197,7 +191,7 @@ pub fn FindFriends(cx: Scope, account: Account, add_error: UseState<String>) -> 
                 on_pressed: move |e: UiEvent<MouseData>| {
                     e.cancel_bubble();
 
-                    let did = DID::try_from(format!("did:key:{}", remote_friend.clone())); 
+                    let did = DID::try_from(format!("did:key:{}", remote_friend.clone()));
                     match did {
                         Ok(d) => {
                             match account.clone()
@@ -224,6 +218,7 @@ pub fn FindFriends(cx: Scope, account: Account, add_error: UseState<String>) -> 
                         },
                         Err(_) => add_error.set(l2.invalid_code.to_string()),
                     }
+                    remote_friend.set("".into());
                 },
             },
             div {

--- a/src/components/main/friends/sidebar/mod.rs
+++ b/src/components/main/friends/sidebar/mod.rs
@@ -152,8 +152,7 @@ pub fn FindFriends(cx: Scope, account: Account, add_error: UseState<String>) -> 
         div {
             class: "add",  
             InputAddFriend{
-                    // TODO:add placeholder
-                    // placeholder: l.add_placeholder.clone(),
+                    placeholder: l.add_placeholder.clone(),
                     value: remote_friend.clone(),
                     on_change: move |_| add_error.set(String::new()),
                     on_enter: move |_| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,18 +266,18 @@ fn App(cx: Scope<State>) -> Element {
         AppStyle {},
         span {
             id: "main-wrap",
-            ContextMenu {
-                parent: String::from("main-wrap"),
-                items: cx.render(rsx! {
-                    ContextItem {
-                        icon: Shape::CodeBracketSquare,
-                        text: String::from("View Source"),
-                        onpressed: move |_| {
-                            let _ = open::that("https://github.com/Satellite-im/Uplink");
-                        },
-                    }
-                })
-            },
+            // ContextMenu {
+            //     parent: String::from("main-wrap"),
+            //     items: cx.render(rsx! {
+            //         ContextItem {
+            //             icon: Shape::CodeBracketSquare,
+            //             text: String::from("View Source"),
+            //             onpressed: move |_| {
+            //                 let _ = open::that("https://github.com/Satellite-im/Uplink");
+            //             },
+            //         }
+            //     })
+            // },
             Router {
                 Route { to: "/", unlock::Unlock { tesseract: cx.props.tesseract.clone() } }
                 Route { to: "/loading", loading::Loading { account: cx.props.account.clone() } },

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,18 +266,18 @@ fn App(cx: Scope<State>) -> Element {
         AppStyle {},
         span {
             id: "main-wrap",
-            // ContextMenu {
-            //     parent: String::from("main-wrap"),
-            //     items: cx.render(rsx! {
-            //         ContextItem {
-            //             icon: Shape::CodeBracketSquare,
-            //             text: String::from("View Source"),
-            //             onpressed: move |_| {
-            //                 let _ = open::that("https://github.com/Satellite-im/Uplink");
-            //             },
-            //         }
-            //     })
-            // },
+            ContextMenu {
+                parent: String::from("main-wrap"),
+                items: cx.render(rsx! {
+                    ContextItem {
+                        icon: Shape::CodeBracketSquare,
+                        text: String::from("View Source"),
+                        onpressed: move |_| {
+                            let _ = open::that("https://github.com/Satellite-im/Uplink");
+                        },
+                    }
+                })
+            },
             Router {
                 Route { to: "/", unlock::Unlock { tesseract: cx.props.tesseract.clone() } }
                 Route { to: "/loading", loading::Loading { account: cx.props.account.clone() } },

--- a/src/ui_kit/src/input_add_friend/mod.rs
+++ b/src/ui_kit/src/input_add_friend/mod.rs
@@ -1,0 +1,42 @@
+use dioxus::{events::FormEvent, prelude::*};
+use dioxus_elements::KeyCode;
+
+#[inline_props]
+#[allow(non_snake_case)]
+pub fn InputAddFriend<'a>(
+    cx: Scope,
+    value: UseState<String>,
+    on_change: EventHandler<'a, FormEvent>,
+    on_enter: EventHandler<'a, String>,
+) -> Element<'a> {
+    let clearing_state = &*cx.use_hook(|_| std::cell::Cell::new(false));
+
+    let mut inner_html = cx.use_hook(|_| " ").clone();
+    if !inner_html.is_empty() && value.is_empty() && !clearing_state.get() {
+        inner_html = "";
+        clearing_state.set(true);
+        cx.needs_update();
+    } else {
+        clearing_state.set(false);
+    }
+
+    let res = rsx! {
+            div {
+                class: "input-add-friend",
+                contenteditable: "true",
+                oninput: move |e| {
+                    value.set(e.value.clone());
+                    on_change.call(e);
+                },
+                onkeyup: |e| {
+                    if e.data.key_code.eq(&KeyCode::Enter){
+                        on_enter.call(value.to_string());
+                        value.set(String::from(""));
+                    }
+                },
+                "dangerous_inner_html": "{inner_html}",
+            }
+    };
+
+    cx.render(res)
+}

--- a/src/ui_kit/src/input_add_friend/mod.rs
+++ b/src/ui_kit/src/input_add_friend/mod.rs
@@ -1,3 +1,4 @@
+use crate::context_menu::{ContextItem, ContextMenu};
 use dioxus::{events::FormEvent, prelude::*};
 use dioxus_elements::KeyCode;
 
@@ -5,12 +6,12 @@ use dioxus_elements::KeyCode;
 #[allow(non_snake_case)]
 pub fn InputAddFriend<'a>(
     cx: Scope,
+    placeholder: String,
     value: UseState<String>,
     on_change: EventHandler<'a, FormEvent>,
     on_enter: EventHandler<'a, String>,
 ) -> Element<'a> {
     let clearing_state = &*cx.use_hook(|_| std::cell::Cell::new(false));
-
     let mut inner_html = cx.use_hook(|_| " ").clone();
     if !inner_html.is_empty() && value.is_empty() && !clearing_state.get() {
         inner_html = "";
@@ -21,8 +22,47 @@ pub fn InputAddFriend<'a>(
     }
 
     let res = rsx! {
+        div{
+            class: "input-add-friend",
+            id:"input-add-friend",
+            ContextMenu {
+                parent: String::from("input-add-friend"),
+                items: cx.render(rsx! {
+                    // TODO: copy paste feature
+                    // ContextItem {
+                    //     onpressed: move |_| {
+                    //         let mut clipboard = Clipboard::new().unwrap();
+                    //         let copied_text = clipboard.get_text();
+                    //         match copied_text {
+                    //             Ok(v)=> {println!("text:{}",v);
+                    //         }
+                    //             Err(e)=> println!("Paste text err:{}",e),
+                    //         }
+                    //     },
+                    //     text: String::from("Paste"),
+                    // },
+                    // ContextItem {
+                    //     onpressed: move |_| {},
+                    //     text: String::from("Select All"),
+                    // },
+                    // ContextItem {
+                    //     onpressed: move |_| {},
+                    //     text: String::from("Copy"),
+                    // },
+                    ContextItem {
+                        onpressed: move |_| value.set(String::from("")),
+                        text: String::from("Clear"),
+                    },
+                })
+            },
+            (value.is_empty()).then(|| rsx!{
+                span {
+                    class: "add-friend-placeholder",
+                    "{placeholder}"
+                },
+            }),
             div {
-                class: "input-add-friend",
+                class: "textfield-add-friend",
                 contenteditable: "true",
                 oninput: move |e| {
                     value.set(e.value.clone());
@@ -35,7 +75,8 @@ pub fn InputAddFriend<'a>(
                     }
                 },
                 "dangerous_inner_html": "{inner_html}",
-            }
+            },
+        }
     };
 
     cx.render(res)

--- a/src/ui_kit/src/input_add_friend/styles.scss
+++ b/src/ui_kit/src/input_add_friend/styles.scss
@@ -1,0 +1,19 @@
+.input-add-friend {
+  min-width: 100px;
+  width: 100%;
+  height: 40px;
+  max-lines: 1;
+  padding: 0.5rem;
+  color: var(--theme-text);
+  border-radius: 4px;
+  border: none;
+  outline: none;
+  background: var(--theme-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
+  [contenteditable="true"] {
+    outline: none;
+    border: none;
+  }
+}

--- a/src/ui_kit/src/input_add_friend/styles.scss
+++ b/src/ui_kit/src/input_add_friend/styles.scss
@@ -1,19 +1,29 @@
 .input-add-friend {
-  min-width: 100px;
-  width: 100%;
   height: 40px;
-  max-lines: 1;
-  padding: 0.5rem;
-  color: var(--theme-text);
-  border-radius: 4px;
-  border: none;
-  outline: none;
-  background: var(--theme-foreground);
+  width: 100%;
+  position: relative;
   white-space: nowrap;
-  overflow: hidden;
   text-overflow: clip;
-  [contenteditable="true"] {
-    outline: none;
-    border: none;
+  overflow: hidden;
+
+  .textfield-add-friend {
+    height: 40px;
+    width: 100%;
+    padding: 10px;
+    white-space: nowrap;
+    text-overflow: clip;
+    overflow: hidden;
+    background: var(--theme-foreground);
+    caret-color: var(--theme-text);
+    border-radius: 4px;
+  }
+
+  .add-friend-placeholder {
+    position: fixed;
+    z-index: 2;
+    color: var(--theme-placeholder);
+    pointer-events: none;
+    margin-top: 10px;
+    margin-left: 10px;
   }
 }

--- a/src/ui_kit/src/lib.rs
+++ b/src/ui_kit/src/lib.rs
@@ -6,6 +6,7 @@ pub mod extension_placeholder;
 pub mod file;
 pub mod folder;
 pub mod input;
+pub mod input_add_friend;
 pub mod loader;
 pub mod new_folder;
 pub mod numeric_indicator;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Delete the text after searching/adding a friend (on_enter or click add button).
- Add a clear feature(right-click the text field) to delete the text.

https://user-images.githubusercontent.com/14248245/205173302-a098d15f-9331-4514-9c08-071e8645465a.mov



### Which issue(s) this PR fixes 🔨
- Resolve #302 
- Resolve #286 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤
- The input effect looks still not perfect since it has a moving-up effect which comes with a contenteditable div. Hope we can solve it in the future. 
- It needs ContextMenu of input(copy/paste/select all) to be finished in the future. 

