### PR TITLE
chore(windows): Update Windows Build

### DIFF
--- a/.github/workflows/ci-make-dmg.yml
+++ b/.github/workflows/ci-make-dmg.yml
@@ -9,7 +9,6 @@ on:
       - "*"
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  CARGO_TERM_COLOR: always
 
 jobs:
   build_sign_macos:
@@ -27,26 +26,31 @@ jobs:
         continue-on-error: true
         run: |
           brew update
-          brew install protobuf
+          brew install protobuf 
+          brew install cmake rustup-init gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav gst-rtsp-server gst-editing-services
       - name: Add Targets
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
         run: |
           rustup target add x86_64-apple-darwin aarch64-apple-darwin
       - name: Codesign and Build executable
+        continue-on-error: true
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+          MACOS_KEYCHAIN_NAME: ${{ secrets.MACOS_KEYCHAIN_NAME }}
         run: |
           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain 
+          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
           security default-keychain -s builduplink.keychain
           security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
           security set-keychain-settings builduplink.keychain
           security import certificate.p12 -k builduplink.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" builduplink.keychain
+          security find-identity -p codesigning -v
+          security list-keychains
           make dmg-universal
       - name: "Notarize executable"
         env:

--- a/.github/workflows/ci-make-windows.yml
+++ b/.github/workflows/ci-make-windows.yml
@@ -1,0 +1,41 @@
+# https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
+## TODO: Once we get the EV certificate, make this code-sign the windows exe so we dont have that nasty error message
+name: Make Windows Executable
+
+# Watch for tags being created, after self hosted runner setup we can change this back, or make it when a user manually requests a dmg
+on:
+  push:
+    tags:
+      - '*' 
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+      - name: Use cmake
+        run: cmake --version
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+      - name: Build resources
+        run: cargo build
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Uplink-Windows
+          path: |
+            target/debug/uplink.exe

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(run), windows_subsystem = "windows")]
 use crate::iutils::config::Config;
 use ::utils::Account;
 use clap::Parser;
@@ -43,9 +44,8 @@ pub mod themes;
 
 use tao::window::WindowBuilder;
 
+use state::{self, STATE};
 use tao::menu::{MenuBar as Menu, MenuItem};
-use state::STATE;
-use state;
 
 static TOAST_MANAGER: AtomRef<ToastManager> = |_| ToastManager::default();
 static LANGUAGE: AtomRef<Language> = |_| Language::by_locale(AvailableLanguages::EnUS);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
This adds basic windows builds on tag creation (so for release).

Windows is not signed yet, still working with comodo on that, so you have to click through the error message

This also makes it so you dont see cmd prompt in the background when running windows (top line on main.rs).

This was originally going to use the self hosted runner but i dont have time to finish debugging it.

To see a copy of the windows output, check here: https://github.com/Satellite-im/Uplink/actions/runs/3644303138 in the artifacts

### Which issue(s) this PR fixes 🔨
- Resolve #458
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
The changes go main.rs, except for the very first line, are because of the linter

### Additional comments 🎤

