### PR TITLE
fix(replies): change order in which message replies are displayed

### DIFF
--- a/src/components/main/compose/messages/mod.rs
+++ b/src/components/main/compose/messages/mod.rs
@@ -357,6 +357,27 @@ pub fn Messages(cx: Scope<Props>) -> Element {
                             key: "{message_id}",
                             style: "display: contents",
                             "data-remote": "{is_remote}",
+                            message.replied().map(|replied| {
+                                let r = cx.props.messaging.clone();
+                                match warp::async_block_in_place_uncheck(r.get_message(conversation_id, replied)) {
+                                    Ok(message) => {
+                                        rsx!{
+                                            Reply {
+                                                // key: "{message_id}-reply",
+                                                message_id: message.id(),
+                                                message: message.value().join("\n"),
+                                                attachments_len: message.attachments().len(),
+                                                is_remote: is_remote,
+                                                account: cx.props.account.clone(),
+                                                sender: message.sender(),
+                                            }
+                                        }
+                                    },
+                                    // todo: if we don't want to display this, change message.replied().map to message.replied.and_then(), then 
+                                    // in the match statement return Some(Element) on Ok and None on error, with error logging as desired. 
+                                    Err(_) => { rsx!{ span { "Something went wrong" } } }
+                                }
+                            }),
                             Msg {
                                 // key: "{message_id}-reply",
                                 messaging: cx.props.messaging.clone(),message: message.clone(),
@@ -372,28 +393,6 @@ pub fn Messages(cx: Scope<Props>) -> Element {
                                         //TODO: Display error?
                                     }
                                 }
-                            }
-                            match message.replied() {
-                                Some(replied) => {
-                                    let r = cx.props.messaging.clone();
-                                    match warp::async_block_in_place_uncheck(r.get_message(conversation_id, replied)) {
-                                        Ok(message) => {
-                                            rsx!{
-                                                Reply {
-                                                    // key: "{message_id}-reply",
-                                                    message_id: message.id(),
-                                                    message: message.value().join("\n"),
-                                                    attachments_len: message.attachments().len(),
-                                                    is_remote: is_remote,
-                                                    account: cx.props.account.clone(),
-                                                    sender: message.sender(),
-                                                }
-                                            }
-                                        },
-                                        Err(_) => { rsx!{ span { "Something went wrong" } } }
-                                    }
-                                },
-                                _ => rsx!{ div {  } }
                             }
                         }
                     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- when a received message is a reply, part of the message being replied to is displayed. this PR displays it above the message rather than below it. 

### Which issue(s) this PR fixes 🔨
- Resolve #549 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

