### PR TITLE
update(FriendListTile): add More button for deleting and blocking friends

### DIFF
--- a/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/mod.rs
+++ b/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/mod.rs
@@ -22,9 +22,9 @@ pub fn MoreMenu(cx: Scope<MoreMenuProps>) -> Element {
                                 let mut multipass = cx.props.account.clone();
                                 let did_to_remove = cx.props.friend.clone();
                                 match multipass.remove_friend(&did_to_remove) {
-                                    Ok(_) => {}
-                                    Err(_) => {
-                                        log::debug!("error removing friend");
+                                    Ok(_) => {log::info!("removing friend succeed")}
+                                    Err(e) => {
+                                        log::error!("failed in removing friend : {}",e.to_string());
                                     }
                                 }
                                 //todo: remove the conversation?

--- a/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/mod.rs
+++ b/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/mod.rs
@@ -11,9 +11,11 @@ pub struct MoreMenuProps {
 
 #[allow(non_snake_case)]
 pub fn MoreMenu(cx: Scope<MoreMenuProps>) -> Element {
+    let friend_id = &cx.props.friend.to_string()[8..];
+    let script = include_str!("./more_menu.js").replace("friend_id", &friend_id);
+
     let more_memu = rsx!(
-        div { class: "more_menu",
-                    Button {
+            Button {
                         text:"Remove Friend".to_string(),
                         state: ui_kit::button::State::Transparent,
                         on_pressed: move |_| {
@@ -28,7 +30,7 @@ pub fn MoreMenu(cx: Scope<MoreMenuProps>) -> Element {
                                 //todo: remove the conversation?
                             }
                         },
-                        Button {
+            Button {
                             text:"Block Friend".to_string(),
                             state: ui_kit::button::State::Transparent,
                             on_pressed: move |_| {
@@ -41,7 +43,8 @@ pub fn MoreMenu(cx: Scope<MoreMenuProps>) -> Element {
                                      }
                                  }
                              }
-                         },}
+                    },
+            script { "{script}"}
     );
     cx.render(more_memu)
 }

--- a/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/mod.rs
+++ b/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/mod.rs
@@ -1,0 +1,47 @@
+use dioxus::prelude::*;
+use ui_kit::button::Button;
+use utils::Account;
+use warp::crypto::DID;
+
+#[derive(Props, PartialEq)]
+pub struct MoreMenuProps {
+    account: Account,
+    friend: DID,
+}
+
+#[allow(non_snake_case)]
+pub fn MoreMenu(cx: Scope<MoreMenuProps>) -> Element {
+    let more_memu = rsx!(
+        div { class: "more_menu",
+                    Button {
+                        text:"Remove Friend".to_string(),
+                        state: ui_kit::button::State::Transparent,
+                        on_pressed: move |_| {
+                                let mut multipass = cx.props.account.clone();
+                                let did_to_remove = cx.props.friend.clone();
+                                match multipass.remove_friend(&did_to_remove) {
+                                    Ok(_) => {}
+                                    Err(_) => {
+                                        log::debug!("error removing friend");
+                                    }
+                                }
+                                //todo: remove the conversation?
+                            }
+                        },
+                        Button {
+                            text:"Block Friend".to_string(),
+                            state: ui_kit::button::State::Transparent,
+                            on_pressed: move |_| {
+                                 let mut multipass = cx.props.account.clone();
+                                 let did_to_block = cx.props.friend.clone();
+                                 match multipass.block(&did_to_block) {
+                                     Ok(_) => {}
+                                     Err(e) => {
+                                         log::debug!("faied to block friend {}:{}", &cx.props.friend, e);
+                                     }
+                                 }
+                             }
+                         },}
+    );
+    cx.render(more_memu)
+}

--- a/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/more_menu.js
+++ b/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/more_menu.js
@@ -1,0 +1,10 @@
+document.addEventListener("click", (event) => {
+  //close the more menu when clicking outside of it and outside of more button
+  if (
+    !more_menu.contains(event.target) &&
+    !more_button.contains(event.target)
+  ) {
+    more_menu.style.display = "none"
+    removeEventListener("click")
+  }
+})

--- a/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/styles.scss
+++ b/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/styles.scss
@@ -1,0 +1,10 @@
+.more_menu {
+  position: fixed;
+  border-radius: 4px;
+  background: var(--theme-secondary);
+  z-index: 100;
+  flex-direction: column;
+  padding: 2px;
+  right: 35px;
+  margin-top: 8px;
+}

--- a/src/components/main/friends/users_list/friend_list/friend_list_tile/show_more_menu.js
+++ b/src/components/main/friends/users_list/friend_list/friend_list_tile/show_more_menu.js
@@ -1,0 +1,9 @@
+var more_menu = document.getElementById("friend_id-more-menu")
+var more_button = document.getElementById("friend_id-more-button")
+//for more_menu.js to get the more_button
+
+if (more_menu.style.display == "none") {
+  more_menu.style.display = "block"
+} else {
+  more_menu.style.display = "none"
+}

--- a/src/components/main/settings/pages/extensions/extension.rs
+++ b/src/components/main/settings/pages/extensions/extension.rs
@@ -1,9 +1,9 @@
+use crate::state::Actions;
+use crate::STATE;
 use dioxus::prelude::*;
 use dioxus_heroicons::{outline::Shape, Icon};
 use ui_kit::switch::Switch;
 use utils::extensions::ExtensionInfo;
-use crate::STATE;
-use crate::state::Actions;
 
 #[derive(Props, Eq, PartialEq)]
 pub struct Props {
@@ -17,10 +17,11 @@ pub fn ExtensionOptions(cx: Scope<Props>) -> Element {
     let state = use_atom_ref(&cx, STATE);
     let name = &cx.props.extension.name;
     let is_enabled = state.read().enabled_extensions.contains(name);
-    let toggle = move |_| state.write().dispatch(
-        Actions::SetExtensionEnabled(name.clone(), !is_enabled)
-    );
-
+    let toggle = move |_| {
+        state
+            .write()
+            .dispatch(Actions::SetExtensionEnabled(name.clone(), !is_enabled))
+    };
 
     cx.render(rsx! {
         div {

--- a/src/components/main/sidebar/mod.rs
+++ b/src/components/main/sidebar/mod.rs
@@ -57,7 +57,11 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
     }
 
     let ext_enabled = state.read().enabled_extensions.clone();
-    let exts = get_renders(ExtensionType::SidebarWidget, config.extensions.enable, ext_enabled);
+    let exts = get_renders(
+        ExtensionType::SidebarWidget,
+        config.extensions.enable,
+        ext_enabled,
+    );
 
     let notifications_tx = use_coroutine(&cx, |mut rx: UnboundedReceiver<Message>| async move {
         while let Some(msg) = rx.next().await {

--- a/src/state/src/lib.rs
+++ b/src/state/src/lib.rs
@@ -248,7 +248,6 @@ impl PersistedState {
                         self.enabled_extensions.retain(|x| *x != name);
                     }
                 }
-
             }
             Actions::SetShowPrerelaseNotice(value) => {
                 log::debug!("PersistedState: SetShowPrerelaseNotice");

--- a/src/ui_kit/src/button/mod.rs
+++ b/src/ui_kit/src/button/mod.rs
@@ -36,10 +36,7 @@ pub fn Button<'a>(cx: Scope<'a, Props>) -> Element<'a> {
         None => String::from(""),
     };
 
-    let hide_text = match cx.props.hide_text.clone() {
-        Some(v) => v,
-        None => false,
-    };
+    let hide_text = cx.props.hide_text.unwrap_or(false);
 
     let mut class = String::from("button ");
     class += match cx.props.large {

--- a/src/ui_kit/src/button/mod.rs
+++ b/src/ui_kit/src/button/mod.rs
@@ -36,6 +36,11 @@ pub fn Button<'a>(cx: Scope<'a, Props>) -> Element<'a> {
         None => String::from(""),
     };
 
+    let hide_text = match cx.props.hide_text.clone() {
+        Some(v) => v,
+        None => false,
+    };
+
     let mut class = String::from("button ");
     class += match cx.props.large {
         Some(_) => "button-lg ",
@@ -53,7 +58,7 @@ pub fn Button<'a>(cx: Scope<'a, Props>) -> Element<'a> {
         None => "",
     };
     // add class if text length is 0
-    if text.is_empty() {
+    if text.is_empty() || hide_text {
         class += " button-icon-only";
     }
 

--- a/src/utils/src/extensions.rs
+++ b/src/utils/src/extensions.rs
@@ -128,7 +128,11 @@ impl ExtensionManager {
 }
 
 #[allow(non_snake_case)]
-pub fn get_renders<'src>(location: ExtensionType, enable: bool, ext_enabled: Vec<String>) -> Vec<LazyNodes<'src, 'src>> {
+pub fn get_renders<'src>(
+    location: ExtensionType,
+    enable: bool,
+    ext_enabled: Vec<String>,
+) -> Vec<LazyNodes<'src, 'src>> {
     if enable {
         let extensions = ExtensionManager::instance().extensions.get(&location);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Add` More` button in the friend list tile. After clicking it, it will show `MoreMenu` to let user choose to remove/block a friend
- Click any area except `More` button and `MoreMenu`, it will close the `MoreMenu`
- Add tooltip for icon only button, when user hovers over an icon button, it will show button text. In this PR, I added 'Message' and 'More' on the corresponding button. 

https://user-images.githubusercontent.com/14248245/206823085-c1456648-ce8a-40a8-b069-4d9e741283ff.mov



### Which issue(s) this PR fixes 🔨
- Resolve #554 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

