### PR TITLE
feat(popout): create reusable popout component

### DIFF
--- a/src/components/main/compose/msg/mod.rs
+++ b/src/components/main/compose/msg/mod.rs
@@ -14,7 +14,7 @@ use utils::Account;
 use warp::{crypto::DID, raygun::Message};
 
 use crate::{
-    components::reusable::textarea::TextArea,
+    components::reusable::{popout::Popout, textarea::TextArea},
     iutils::{
         self,
         get_meta::{get_meta, SiteMeta},
@@ -150,77 +150,66 @@ pub fn Msg<'a>(cx: Scope<'a, Props>) -> Element<'a> {
     cx.render(rsx! (
         div {
             class: "wrapper {remote}",
-            (popout).then(|| rsx!(
+            Popout {
+                is_visible: popout.clone(),
+                remote: remote.to_string(),
                 div {
-                    class: "popout-mask {remote}",
+                    class: "message-wrap {slide_class}",
                     div {
-                        class: "close",
-                        Button {
-                            icon: Shape::XMark,
-                            on_pressed: move |_| {
-                                popout.set(false);
-                            }
+                        class: "user-message",
+                        onclick: move |e| {
+                            e.cancel_bubble();
                         },
-                    },
-                    div {
-                        class: "message-wrap {slide_class}",
+                        PFP {
+                            src: cx.props.profile_picture.clone(),
+                            size: ui_kit::profile_picture::Size::Normal
+                        },
                         div {
-                            class: "user-message",
-                            onclick: move |e| {
-                                e.cancel_bubble();
-                            },
-                            PFP {
-                                src: cx.props.profile_picture.clone(),
-                                size: ui_kit::profile_picture::Size::Normal
-                            },
+                            class: "value popout {first} {middle} {last}",
                             div {
-                                class: "value popout {first} {middle} {last}",
-                                div {
-                                    class: "message-content",
-                                    dangerous_inner_html: "{output1}",
-                                    has_links.then(|| rsx!{
-                                        LinkEmbed {
-                                            meta: meta2
-                                        }
-                                    }),
-                                    div {
-                                        attachment_list2
+                                class: "message-content",
+                                dangerous_inner_html: "{output1}",
+                                has_links.then(|| rsx!{
+                                    LinkEmbed {
+                                        meta: meta2
                                     }
-                                },
-                            },
-                        }
-                        div {
-                            class: "controls reply-container",
-                            onclick: move |e| {
-                                e.cancel_bubble();
-                            },
-                            Button {
-                                icon: Shape::FaceSmile,
-                                on_pressed: move |_| {}
-                            },
-                            TextArea {
-                                messaging: cx.props.messaging.clone(),
-                                placeholder: l.send_a_reply.to_string(),
-                                on_input: move |_| {}
-                                on_submit: move |e| {
-                                    cx.props.on_reply.call(e);
-
-                                    popout.set(false);
-                                },
-                                text: text.clone(),
-                            },
-                            Button {
-                                icon: Shape::ArrowRight,
-                                state: ui_kit::button::State::Secondary,
-                                on_pressed: move |_| {
-                                    cx.props.on_reply.call(text.clone().to_string());
-                                    popout.set(false);
+                                }),
+                                div {
+                                    attachment_list2
                                 }
+                            },
+                        },
+                    }
+                    div {
+                        class: "controls reply-container",
+                        onclick: move |e| {
+                            e.cancel_bubble();
+                        },
+                        Button {
+                            icon: Shape::FaceSmile,
+                            on_pressed: move |_| {}
+                        },
+                        TextArea {
+                            messaging: cx.props.messaging.clone(),
+                            placeholder: l.send_a_reply.to_string(),
+                            on_input: move |_| {}
+                            on_submit: move |e| {
+                                cx.props.on_reply.call(e);
+                                popout.set(false);
+                            },
+                            text: text.clone(),
+                        },
+                        Button {
+                            icon: Shape::ArrowRight,
+                            state: ui_kit::button::State::Secondary,
+                            on_pressed: move |_| {
+                                cx.props.on_reply.call(text.clone().to_string());
+                                popout.set(false);
                             }
                         }
                     }
                 }
-            )),
+            },
             div {
                 class: "message {remote} {hover_class}",
                 id: "{id}-message",

--- a/src/components/main/compose/msg/styles.scss
+++ b/src/components/main/compose/msg/styles.scss
@@ -149,64 +149,42 @@
       }
     }
   }
+}
 
-  .popout-mask {
+.message-wrap {
+  display: inline-flex;
+  flex-direction: column;
+  position: absolute;
+  padding: 8px;
+  max-width: 520px;
+
+  .controls,
+  .user-message {
     align-items: center;
-    -webkit-backdrop-filter: blur(5px);
-    backdrop-filter: blur(5px);
-    bottom: 0;
     display: inline-flex;
-    justify-content: center;
-    left: var(--sidebar-width);
-    overflow: hidden;
-    position: fixed;
-    right: 0;
-    top: 0;
-    transition: blur 0.2s;
-    z-index: 2;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-bottom: var(--padding-small);
 
-    .close {
-      position: absolute;
-      top: 1rem;
-      right: 1rem;
-    }
+    .icon-input {
+      margin: 0 var(--padding-small);
+      min-width: unset;
 
-    .message-wrap {
-      display: inline-flex;
-      flex-direction: column;
-      position: absolute;
-      z-index: 3;
-      padding: 8px;
-
-      .controls,
-      .user-message {
-        align-items: center;
-        display: inline-flex;
-        flex-direction: row;
-        justify-content: space-between;
-        margin-bottom: var(--padding-small);
-
-        .icon-input {
-          margin: 0 var(--padding-small);
-          min-width: unset;
-
-          .input {
-            border-radius: 20px;
-          }
-        }
-      }
-
-      .value {
-        border-radius: 16px 16px 16px 4px;
-        max-width: 280px;
-        text-align: left;
-        word-break: break-all;
-      }
-
-      .pfp {
-        margin-right: var(--padding-small);
+      .input {
+        border-radius: 20px;
       }
     }
+  }
+
+  .value {
+    border-radius: 16px 16px 16px 4px;
+    max-width: 280px;
+    text-align: left;
+    word-break: break-all;
+  }
+
+  .pfp {
+    margin-right: var(--padding-small);
   }
 }
 

--- a/src/components/main/files/mod.rs
+++ b/src/components/main/files/mod.rs
@@ -1,6 +1,5 @@
 use dioxus::prelude::*;
 
-// use crate::components::main::files::sidebar::usage::{Usage, UsageStats};
 use crate::{
     components::main::files::{
         browser::FileBrowser, sidebar::Sidebar, toolbar::Toolbar, upload::Upload,
@@ -33,8 +32,8 @@ pub fn Files(cx: Scope<Props>) -> Element {
 
     let st = use_atom_ref(&cx, STATE).clone();
     let sidebar_visibility = match st.read().hide_sidebar {
-        false => "sidebar-visible",
-        true => "sidebar-hidden",
+        false => "mobile-sidebar-visible",
+        true => "mobile-sidebar-hidden",
     };
 
     cx.render(rsx! {

--- a/src/components/main/sidebar/mod.rs
+++ b/src/components/main/sidebar/mod.rs
@@ -57,7 +57,11 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
     }
 
     let ext_enabled = state.read().enabled_extensions.clone();
-    let exts = get_renders(ExtensionType::SidebarWidget, config.extensions.enable, ext_enabled);
+    let exts = get_renders(
+        ExtensionType::SidebarWidget,
+        config.extensions.enable,
+        ext_enabled,
+    );
 
     let notifications_tx = use_coroutine(&cx, |mut rx: UnboundedReceiver<Message>| async move {
         while let Some(msg) = rx.next().await {
@@ -195,8 +199,9 @@ pub fn Sidebar(cx: Scope<Props>) -> Element {
                                     is_active: active_chat == Some(conversation_info.conversation.id()),
                                     tx_chan: notifications_tx.clone(),
                                     on_pressed: move |uuid| {
-                                        // on press, change state so CSS class flips to show the chat
-                                        //state.write().dispatch(Actions::HideSidebar(true));
+                                        // hide the sidebar if it's visible for mobile view
+                                        state.write().dispatch(Actions::HideSidebar(true));
+
                                         if *active_chat != Some(uuid) {
                                             state.write().dispatch(Actions::ShowConversation(conversation_info.conversation.id()));
                                             active_chat.set(Some(uuid));

--- a/src/components/main/styles.scss
+++ b/src/components/main/styles.scss
@@ -45,10 +45,6 @@
       height: 100%;
       position: absolute;
     }
-
-    .popout-mask {
-      left: 0;
-    }
   }
 
   #files,

--- a/src/components/reusable/mod.rs
+++ b/src/components/reusable/mod.rs
@@ -1,5 +1,6 @@
 pub mod nav;
 pub mod page_header;
+pub mod popout;
 pub mod sidebar;
 pub mod textarea;
 pub mod toolbar;

--- a/src/components/reusable/page_header/mod.rs
+++ b/src/components/reusable/page_header/mod.rs
@@ -16,7 +16,7 @@ pub struct Props<'a> {
 #[allow(non_snake_case)]
 pub fn PageHeader<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
     // Log a debug message
-    log::debug!("rendering PageHeading");
+    log::debug!("rendering PageHeader");
 
     // Determine the visibility class for the page header
     let header_visibility = match cx.props.hide_on_desktop {

--- a/src/components/reusable/popout/mod.rs
+++ b/src/components/reusable/popout/mod.rs
@@ -1,0 +1,38 @@
+use dioxus::prelude::*;
+use dioxus_heroicons::outline::Shape;
+use ui_kit::button::Button;
+
+#[inline_props]
+#[allow(non_snake_case)]
+pub fn Popout<'a>(
+    cx: Scope,
+    is_visible: UseState<bool>,
+    remote: String,
+    children: Element<'a>,
+) -> Element<'a> {
+    // Log a debug message
+    log::debug!("rendering Popout");
+
+    if !is_visible.get() {
+        return None.into();
+    }
+
+    cx.render(rsx! {
+       div {
+            id: "popout",
+            div {
+                class: "popout-mask {remote}",
+                children,
+                div {
+                    class: "close",
+                    Button {
+                        icon: Shape::XMark,
+                        on_pressed: move |_| {
+                            is_visible.set(false);
+                        }
+                    },
+                },
+            },
+        }
+    })
+}

--- a/src/components/reusable/popout/styles.scss
+++ b/src/components/reusable/popout/styles.scss
@@ -1,0 +1,27 @@
+#popout {
+  .popout-mask {
+    z-index: 2;
+    align-items: center;
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+    bottom: 0;
+    display: inline-flex;
+    justify-content: center;
+    left: var(--sidebar-width);
+    overflow: hidden;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transition: blur 0.2s;
+
+    .close {
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+    }
+
+    @media only screen and (max-width: 600px) {
+      left: 0;
+    }
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Creates a reusable component for popouts
- Refactors message replies to use new popout component
- Fixes mobile layouts for chat and files screens

### Which issue(s) this PR fixes 🔨
- Resolve #561 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Additional comments 🎤
- This PR unblocks #562 