### PR TITLE
feat(uikit): add missing props to select component

### DIFF
--- a/extensions/native/audio-factory/src/lib.rs
+++ b/extensions/native/audio-factory/src/lib.rs
@@ -5,7 +5,7 @@ use sir::css;
 
 use ui_kit::{
     button::{self, Button},
-    select::Select,
+    select::*,
     switch::Switch,
 };
 use utils::extensions::{BasicExtension, ExtensionInfo, ExtensionType};
@@ -276,7 +276,10 @@ pub fn ExtAudioFactory(cx: Scope<Props>) -> Element {
                                 children: cx.render(rsx! {
                                     Select {
                                         on_change: move |_v| {},
-                                        options: vec![String::from("MP4")]
+                                        value: String::from("mp4"),
+                                        options: vec![
+                                            SelectOption { label: String::from("MP4"), value: String::from("mp4") },
+                                        ]
                                     }
                                 })
                             },
@@ -288,8 +291,24 @@ pub fn ExtAudioFactory(cx: Scope<Props>) -> Element {
                             children: cx.render(rsx! {
                                 Select {
                                     on_change: move |_v| {},
+                                    value: String::from("720-30"),
                                     // TODO: Automate this
-                                    options: vec![String::from("8K-120"), String::from("8K-60"), String::from("4K-120"), String::from("4K-60"), String::from("4K-30"), String::from("1080-120"), String::from("1080-60"), String::from("1080-30"), String::from("720-120"), String::from("720-60"), String::from("720-30"), String::from("360-120"), String::from("360-60"), String::from("360-30")]
+                                    options: vec![
+                                        SelectOption { label: String::from("8K-120"), value: String::from("8K-120") },
+                                        SelectOption { label: String::from("8K-60"), value: String::from("8K-60") },
+                                        SelectOption { label: String::from("4K-120"), value: String::from("4K-120") },
+                                        SelectOption { label: String::from("4K-60"), value: String::from("4K-60") },
+                                        SelectOption { label: String::from("4K-30"), value: String::from("4K-30") },
+                                        SelectOption { label: String::from("1080-120"), value: String::from("1080-120") },
+                                        SelectOption { label: String::from("1080-60"), value: String::from("1080-60") },
+                                        SelectOption { label: String::from("1080-30"), value: String::from("1080-30") },
+                                        SelectOption { label: String::from("720-120"), value: String::from("720-120") },
+                                        SelectOption { label: String::from("720-60"), value: String::from("720-60") },
+                                        SelectOption { label: String::from("720-30"), value: String::from("720-30") },
+                                        SelectOption { label: String::from("360-120"), value: String::from("360-120") },
+                                        SelectOption { label: String::from("360-60"), value: String::from("360-60") },
+                                        SelectOption { label: String::from("360-30"), value: String::from("360-30") }
+                                    ]
                                 }
                             })
                         },
@@ -302,7 +321,23 @@ pub fn ExtAudioFactory(cx: Scope<Props>) -> Element {
                                 children: cx.render(rsx! {
                                     Select {
                                         on_change: move |_v| {},
-                                        options: vec![String::from("FFV1"), String::from("FAAC"), String::from("HEVC"), String::from("AAC"), String::from("Ape"), String::from("AIFF"), String::from("FLAC"), String::from("MP3"), String::from("MP4"), String::from("Opus"), String::from("Ogg Vorbis"), String::from("Speex"), String::from("Wav"), String::from("WavPack")]
+                                        value: String::from("mp3"),
+                                        options: vec![
+                                            SelectOption { label: String::from("FFV1"), value: String::from("ffv1") },
+                                            SelectOption { label: String::from("FAAC"), value: String::from("faac") },
+                                            SelectOption { label: String::from("HEVC"), value: String::from("hevc") },
+                                            SelectOption { label: String::from("AAC"), value: String::from("aac") },
+                                            SelectOption { label: String::from("Ape"), value: String::from("ape") },
+                                            SelectOption { label: String::from("AIFF"), value: String::from("aiff") },
+                                            SelectOption { label: String::from("FLAC"), value: String::from("flac") },
+                                            SelectOption { label: String::from("MP3"), value: String::from("mp3") },
+                                            SelectOption { label: String::from("MP4"), value: String::from("mp4") },
+                                            SelectOption { label: String::from("Opus"), value: String::from("opus") },
+                                            SelectOption { label: String::from("Ogg Vorbis"), value: String::from("ogg vorbis") },
+                                            SelectOption { label: String::from("Speex"), value: String::from("speex") },
+                                            SelectOption { label: String::from("Wav"), value: String::from("wav") },
+                                            SelectOption { label: String::from("WavPack"), value: String::from("wavpack") }
+                                        ]
                                     }
                                 })
                             },
@@ -314,7 +349,10 @@ pub fn ExtAudioFactory(cx: Scope<Props>) -> Element {
                             children: cx.render(rsx! {
                                 Select {
                                     on_change: move |_v| {},
-                                    options: vec![String::from("LOSSLESS")]
+                                    value: String::from("lossless"),
+                                    options: vec![
+                                        SelectOption { label: String::from("LOSSLESS"), value: String::from("lossless") }
+                                    ]
                                 }
                             })
                         },

--- a/src/components/main/friends/find/mod.rs
+++ b/src/components/main/friends/find/mod.rs
@@ -9,10 +9,7 @@ use dioxus_toast::{Position, ToastInfo};
 
 use crate::{Account, LANGUAGE, TOAST_MANAGER};
 
-use ui_kit::{
-    button::Button,
-    input::{Input, SelectOption},
-};
+use ui_kit::{button::Button, input::Input, select::SelectOption};
 
 use warp::{crypto::DID, multipass::identity::Identifier};
 

--- a/src/components/main/settings/pages/general/mod.rs
+++ b/src/components/main/settings/pages/general/mod.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 
 use crate::{iutils::config::Config, Account};
-use ui_kit::switch::Switch;
+use ui_kit::{input::*, select::*, switch::Switch};
 
 #[derive(Props, PartialEq)]
 pub struct Props {
@@ -36,6 +36,28 @@ pub fn General(cx: Scope<Props>) -> Element {
                             config.general.show_splash = !config.general.show_splash;
                             let _ = config.save();
                         }
+                    }
+                }
+            }
+            div {
+                class: "item",
+                div {
+                    class: "description",
+                    label {
+                        "Theme"
+                    },
+                    p {
+                        "Select a theme for Uplink."
+                    },
+                },
+                div {
+                    class: "interactive",
+                    Select {
+                        on_change: move |_| {},
+                        value: String::from("dark"),
+                        options: vec![
+                            SelectOption { value: String::from("dark"), label: String::from("Dark") },
+                        ]
                     }
                 }
             }

--- a/src/ui_kit/src/input/mod.rs
+++ b/src/ui_kit/src/input/mod.rs
@@ -2,17 +2,15 @@ use dioxus::{events::FormEvent, prelude::*};
 use dioxus_elements::KeyCode;
 use dioxus_heroicons::{outline::Shape, Icon};
 
-use crate::context_menu::{ContextItem, ContextMenu};
+use crate::{
+    context_menu::{ContextItem, ContextMenu},
+    select::SelectOption,
+};
 
 #[derive(PartialEq, Eq)]
 pub enum State {
     Success,
     Danger,
-}
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub struct SelectOption {
-    pub value: String,
-    pub label: String,
 }
 
 #[derive(Props)]

--- a/src/ui_kit/src/select/mod.rs
+++ b/src/ui_kit/src/select/mod.rs
@@ -1,18 +1,37 @@
 use dioxus::prelude::*;
 
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct SelectOption {
+    pub value: String,
+    pub label: String,
+}
+
 #[derive(Props)]
 pub struct Props<'a> {
-    options: Vec<String>,
+    options: Vec<SelectOption>,
+    value: String,
     on_change: EventHandler<'a, String>,
 }
 
 #[allow(non_snake_case)]
 pub fn Select<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
-    let iter = IntoIterator::into_iter(cx.props.options.clone());
-    cx.render(rsx!(div { class: "select", select {
-        onchange: move |e| cx.props.on_change.call(e.value.clone()),
-        iter.map(|val| rsx!(
-            option { label: "{val}", value: "{val}" }
-        ))
-    }}))
+    let options = IntoIterator::into_iter(cx.props.options.clone());
+    cx.render(rsx!(
+        div {
+            class: "select",
+            select {
+                onchange: move |e| cx.props.on_change.call(e.value.clone()),
+                options.map(|option| {
+                    let selected = option.value == cx.props.value;
+                    rsx!(
+                        option {
+                            label: "{option.label}",
+                            value: "{option.value}",
+                            selected: "{selected}",
+                        }
+                    )
+                })
+            }
+        }
+    ))
 }

--- a/src/ui_kit/src/select/styles.scss
+++ b/src/ui_kit/src/select/styles.scss
@@ -15,5 +15,6 @@
     background-color: var(--theme-primary);
     outline: none;
     cursor: pointer;
+    user-select: none;
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Add value prop to Select component
- replace options prop type of `Vec<String>` with `Vec<SelectOption>`

### Which issue(s) this PR fixes 🔨
- Resolve #600 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️


### Additional comments 🎤

