### PR TITLE
feat(confirmation-modal): add confirmation modal

### DIFF
--- a/src/components/main/friends/users_list/friend_list/friend_list_tile/mod.rs
+++ b/src/components/main/friends/users_list/friend_list/friend_list_tile/mod.rs
@@ -98,9 +98,9 @@ pub fn FriendListTile<'a>(cx: Scope<'a, Props>) -> Element<'a> {
                                 }
                         },
                         div{
-                            div{
+                            div {
                                 id:"{friend_id}-more-button",
-                                Button{
+                                Button {
                                     icon:Shape::EllipsisVertical,
                                     state: ui_kit::button::State::Secondary,
                                     text: "More".to_string(),
@@ -110,14 +110,15 @@ pub fn FriendListTile<'a>(cx: Scope<'a, Props>) -> Element<'a> {
                                     }
                                 },
                             },
-                            div{
-                                     id:"{friend_id}-more-menu",
-                                     class: "more_menu",
-                                     display: "none",
-                                     MoreMenu{
-                                     account: cx.props.account.clone(),
-                                     friend:cx.props.friend.clone(),
-                                    },
+                            div {
+                                id:"{friend_id}-more-menu",
+                                class: "more_menu",
+                                display: "none",
+                                MoreMenu {
+                                    account: cx.props.account.clone(),
+                                    friend: cx.props.friend.clone(),
+                                    friend_username: cx.props.friend_username.clone(),
+                                },
                             },
                         }
                     )}

--- a/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/mod.rs
+++ b/src/components/main/friends/users_list/friend_list/friend_list_tile/more_menu/mod.rs
@@ -3,10 +3,13 @@ use ui_kit::button::Button;
 use utils::Account;
 use warp::crypto::DID;
 
+use crate::components::reusable::confirmation_modal::ConfirmationModal;
+
 #[derive(Props, PartialEq)]
 pub struct MoreMenuProps {
     account: Account,
     friend: DID,
+    friend_username: String,
 }
 
 #[allow(non_snake_case)]
@@ -14,36 +17,48 @@ pub fn MoreMenu(cx: Scope<MoreMenuProps>) -> Element {
     let friend_id = &cx.props.friend.to_string()[8..];
     let script = include_str!("./more_menu.js").replace("friend_id", &friend_id);
 
+    let block_confirmation_modal_visible = use_state(&cx, || false);
+    let username = cx.props.friend_username.clone();
+    let block_user_description = format!("Are you sure you want to block {}?", username);
+
     let more_memu = rsx!(
             Button {
-                        text:"Remove Friend".to_string(),
-                        state: ui_kit::button::State::Transparent,
-                        on_pressed: move |_| {
-                                let mut multipass = cx.props.account.clone();
-                                let did_to_remove = cx.props.friend.clone();
-                                match multipass.remove_friend(&did_to_remove) {
-                                    Ok(_) => {log::info!("removing friend succeed")}
-                                    Err(e) => {
-                                        log::error!("failed in removing friend : {}",e.to_string());
-                                    }
-                                }
-                                //todo: remove the conversation?
-                            }
-                        },
+                text:"Remove Friend".to_string(),
+                state: ui_kit::button::State::Transparent,
+                on_pressed: move |_| {
+                    let mut multipass = cx.props.account.clone();
+                    let did_to_remove = cx.props.friend.clone();
+                    match multipass.remove_friend(&did_to_remove) {
+                        Ok(_) => {log::info!("removing friend succeed")}
+                        Err(e) => {
+                            log::error!("failed in removing friend : {}",e.to_string());
+                        }
+                    }
+                    //todo: remove the conversation?
+                }
+            },
             Button {
-                            text:"Block Friend".to_string(),
-                            state: ui_kit::button::State::Transparent,
-                            on_pressed: move |_| {
-                                 let mut multipass = cx.props.account.clone();
-                                 let did_to_block = cx.props.friend.clone();
-                                 match multipass.block(&did_to_block) {
-                                     Ok(_) => {}
-                                     Err(e) => {
-                                         log::debug!("faied to block friend {}:{}", &cx.props.friend, e);
-                                     }
-                                 }
-                             }
-                    },
+                text:"Block Friend".to_string(),
+                state: ui_kit::button::State::Transparent,
+                on_pressed: move |_| {
+                    block_confirmation_modal_visible.set(true);
+                }
+            },
+            ConfirmationModal {
+                is_visible: block_confirmation_modal_visible.clone(),
+                title: "Block".to_string(),
+                description: block_user_description,
+                on_confirm: move |_| {
+                    let mut multipass = cx.props.account.clone();
+                    let did_to_block = cx.props.friend.clone();
+                    match multipass.block(&did_to_block) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            log::debug!("faied to block friend {}:{}", &cx.props.friend, e);
+                        }
+                    }
+                }
+            }
             script { "{script}"}
     );
     cx.render(more_memu)

--- a/src/components/reusable/confirmation_modal/mod.rs
+++ b/src/components/reusable/confirmation_modal/mod.rs
@@ -1,8 +1,7 @@
 use dioxus::prelude::*;
-use dioxus_heroicons::outline::Shape;
 use ui_kit::button::Button;
 
-use crate::components::reusable::popout::Popout;
+use crate::{components::reusable::popout::Popout, LANGUAGE};
 
 #[inline_props]
 #[allow(non_snake_case)]
@@ -15,6 +14,7 @@ pub fn ConfirmationModal<'a>(
 ) -> Element<'a> {
     // Log a debug message
     log::debug!("rendering ConfirmationModal");
+    let l = use_atom_ref(&cx, LANGUAGE).read();
 
     let handleConfirmation = move |_| {
         is_visible.set(false);
@@ -25,9 +25,10 @@ pub fn ConfirmationModal<'a>(
        Popout {
            is_visible: is_visible.clone(),
            remote: "confirmation-modal".to_string(),
+           hide_close_button: true,
            div {
                id: "confirmation-modal",
-               h2 {
+               h3 {
                    class: "modal-title",
                    "{title}",
                },
@@ -38,14 +39,14 @@ pub fn ConfirmationModal<'a>(
                div {
                    class: "modal-actions",
                    Button {
-                       icon: Shape::XMark,
+                       text: l.cancel.to_string(),
                        state: ui_kit::button::State::Danger,
                        on_pressed: move |_| {
-                           is_visible.set(false);
+                          is_visible.set(false);
                        }
                    },
                    Button {
-                       icon: Shape::Check,
+                       text: l.confirm.to_string(),
                        on_pressed: handleConfirmation,
                    },
                },

--- a/src/components/reusable/confirmation_modal/mod.rs
+++ b/src/components/reusable/confirmation_modal/mod.rs
@@ -1,0 +1,55 @@
+use dioxus::prelude::*;
+use dioxus_heroicons::outline::Shape;
+use ui_kit::button::Button;
+
+use crate::components::reusable::popout::Popout;
+
+#[inline_props]
+#[allow(non_snake_case)]
+pub fn ConfirmationModal<'a>(
+    cx: Scope,
+    title: String,
+    description: String,
+    is_visible: UseState<bool>,
+    on_confirm: EventHandler<'a, ()>,
+) -> Element<'a> {
+    // Log a debug message
+    log::debug!("rendering ConfirmationModal");
+
+    let handleConfirmation = move |_| {
+        is_visible.set(false);
+        on_confirm.call(());
+    };
+
+    cx.render(rsx! {
+       Popout {
+           is_visible: is_visible.clone(),
+           remote: "confirmation-modal".to_string(),
+           div {
+               id: "confirmation-modal",
+               h2 {
+                   class: "modal-title",
+                   "{title}",
+               },
+               p {
+                   class: "modal-description",
+                   "{description}",
+               },
+               div {
+                   class: "modal-actions",
+                   Button {
+                       icon: Shape::XMark,
+                       state: ui_kit::button::State::Danger,
+                       on_pressed: move |_| {
+                           is_visible.set(false);
+                       }
+                   },
+                   Button {
+                       icon: Shape::Check,
+                       on_pressed: handleConfirmation,
+                   },
+               },
+           },
+       }
+    })
+}

--- a/src/components/reusable/confirmation_modal/styles.scss
+++ b/src/components/reusable/confirmation_modal/styles.scss
@@ -13,7 +13,7 @@
   .modal-description {
     font-size: 1.125rem;
     font-weight: 400;
-    padding-bottom: 0.5rem;
+    padding-bottom: 1rem;
   }
 
   .modal-actions {

--- a/src/components/reusable/confirmation_modal/styles.scss
+++ b/src/components/reusable/confirmation_modal/styles.scss
@@ -18,7 +18,7 @@
 
   .modal-actions {
     display: flex;
-    justify-content: flex-end;
+    justify-content: center;
     gap: 0.5rem;
   }
 }

--- a/src/components/reusable/confirmation_modal/styles.scss
+++ b/src/components/reusable/confirmation_modal/styles.scss
@@ -1,0 +1,24 @@
+#confirmation-modal {
+  padding: 1rem;
+  margin: 16px;
+  background: var(--theme-secondary);
+  border-radius: 20px;
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
+
+  .modal-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+
+  .modal-description {
+    font-size: 1.125rem;
+    font-weight: 400;
+    padding-bottom: 0.5rem;
+  }
+
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+}

--- a/src/components/reusable/mod.rs
+++ b/src/components/reusable/mod.rs
@@ -1,3 +1,4 @@
+pub mod confirmation_modal;
 pub mod nav;
 pub mod page_header;
 pub mod popout;

--- a/src/components/reusable/popout/mod.rs
+++ b/src/components/reusable/popout/mod.rs
@@ -8,6 +8,7 @@ pub fn Popout<'a>(
     cx: Scope,
     is_visible: UseState<bool>,
     remote: String,
+    hide_close_button: Option<bool>,
     children: Element<'a>,
 ) -> Element<'a> {
     // Log a debug message
@@ -23,15 +24,17 @@ pub fn Popout<'a>(
             div {
                 class: "popout-mask {remote}",
                 children,
-                div {
-                    class: "close",
-                    Button {
-                        icon: Shape::XMark,
-                        on_pressed: move |_| {
-                            is_visible.set(false);
-                        }
+                (!hide_close_button.unwrap_or(false)).then(|| rsx! {
+                    div {
+                        class: "close",
+                        Button {
+                            icon: Shape::XMark,
+                            on_pressed: move |_| {
+                                is_visible.set(false);
+                            }
+                        },
                     },
-                },
+                }),
             },
         }
     })

--- a/src/language/en_us.rs
+++ b/src/language/en_us.rs
@@ -67,5 +67,7 @@ pub fn make() -> Language {
         start_one: String::from("Start one"),
         auth_tooltip: String::from("Only four to six characters allowed"),
         new_friend_request: String::from("New Friend Request"),
+        cancel: String::from("Cancel"),
+        confirm: String::from("Confirm"),
     }
 }

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -64,6 +64,8 @@ pub struct Language {
     pub start_one: String,
     pub auth_tooltip: String,
     pub new_friend_request: String,
+    pub cancel: String,
+    pub confirm: String,
 }
 
 impl Language {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
- Adds a reusable confirmation modal component.
- Implements the confirmation modal for when blocking friends.
<img width="982" alt="スクリーンショット 2022-12-13 18 30 01" src="https://user-images.githubusercontent.com/40599535/207253271-24d6027e-0301-41ab-b4ad-e3d6278e6f04.png">
### Which issue(s) this PR fixes 🔨
- Resolve #562
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->