### PR TITLE
update(Folder): Upload files by drop on folder target

### DIFF
--- a/src/components/main/files/browser/mod.rs
+++ b/src/components/main/files/browser/mod.rs
@@ -2,6 +2,7 @@ use std::{collections::HashSet, time::Duration, path::{PathBuf}};
 
 use dioxus::prelude::*;
 use dioxus_heroicons::{Icon, outline::Shape};
+use utils::files_functions;
 
 use crate::Storage;
 use ui_kit::{file::File, folder::{State, Folder}, new_folder::NewFolder};
@@ -65,7 +66,7 @@ pub fn FileBrowser(cx: Scope<Props>) -> Element {
     );
     let root_dir_id = root_directory.id();
     let current_dir_items_len = current_directory.get_items().len();
-    let current_dir_size = format_folder_size(current_directory.size());
+    let current_dir_size = files_functions::format_item_size(current_directory.size());
 
     cx.render(rsx! {
         div {
@@ -182,28 +183,3 @@ pub fn FileBrowser(cx: Scope<Props>) -> Element {
         }
     })
 }
-
-
-fn format_folder_size(folder_size: usize) -> String {
-    if folder_size == 0 {
-        return String::from("0 bytes");
-    }
-    let base_1024: f64 = 1024.0;
-    let size_f64: f64 = folder_size as f64;
-
-    let i = (size_f64.log10() / base_1024.log10()).floor();
-    let size_formatted = size_f64 / base_1024.powf(i);
-
-    let file_size_suffix = ["bytes", "KB", "MB", "GB", "TB"][i as usize];
-    let mut size_formatted_string = format!(
-        "{size:.*} {size_suffix}",
-        1,
-        size = size_formatted,
-        size_suffix = file_size_suffix
-    );
-    if size_formatted_string.contains(".0") {
-        size_formatted_string = size_formatted_string.replace(".0", "");
-    }
-    size_formatted_string
-}
-

--- a/src/components/main/files/upload/mod.rs
+++ b/src/components/main/files/upload/mod.rs
@@ -1,13 +1,10 @@
 use std::{
     cmp::Ordering,
-    ffi::OsStr,
-    io::Cursor,
-    path::{Path, PathBuf},
 };
 
 use dioxus::{
     core::to_owned,
-    desktop::{use_window, wry::webview::FileDropEvent, DesktopContext},
+    desktop::{use_window, wry::webview::FileDropEvent},
     events::MouseEvent,
     prelude::*,
 };
@@ -15,14 +12,9 @@ use dioxus_heroicons::outline::Shape;
 
 use futures::StreamExt;
 use ui_kit::button::Button;
-use warp::{error::Error};
-use image::io::Reader as ImageReader;
-use mime::*;
 use rfd::FileDialog;
-use warp::{constellation::Progression};
-
-use crate::{Storage, DRAG_FILE_EVENT};
-use tokio_util::io::ReaderStream;
+use crate::{DRAG_FILE_EVENT};
+use utils::files_functions;
 
 #[derive(Props)]
 pub struct Props<'a> {
@@ -84,10 +76,12 @@ pub fn Upload<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                             if let FileDropEvent::Dropped(files_local_path) = drag_file_event {
                                 *drag_over_dropzone.write_silent() = false;
                                 for file_path in &files_local_path {
-                                    upload_file(
+                                    files_functions::upload_file(
                                         file_storage.clone(),
                                         file_path.clone(),
                                         eval_script.clone(),
+                                        false,
+                                        None,
                                     )
                                     .await;
                                     tokio::time::sleep(std::time::Duration::from_millis(150)).await;
@@ -170,7 +164,9 @@ pub fn Upload<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                     to_owned![file_storage, files_local_path, eval_script];
                                     async move {
                                         for file_path in &files_local_path {
-                                            upload_file(file_storage.clone(), file_path.clone(), eval_script.clone()).await;
+                                            files_functions::upload_file(file_storage.clone(), file_path.clone(), 
+                                            eval_script.clone(), false,
+                                            None,).await;
                                         }
                                     }
                                 });
@@ -242,167 +238,4 @@ pub fn Upload<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
 fn get_drag_file_event() -> FileDropEvent {
     let drag_file_event = DRAG_FILE_EVENT.read().clone();
     drag_file_event
-}
-
-async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script: DesktopContext) {
-    let mut filename = match file_path
-        .file_name()
-        .map(|file| file.to_string_lossy().to_string())
-    {
-        Some(file) => file,
-        None => return,
-    };
-
-    let local_path = Path::new(&file_path).to_string_lossy().to_string();
-    let mut count_index_for_duplicate_filename = 1;
-    let mut file_storage = file_storage.clone();
-    let original = filename.clone();
-    let file = PathBuf::from(&original);
-    let current_directory = match file_storage.current_directory() {
-        Ok(current_dir) => current_dir, 
-        _ => return
-    };
-
-    loop {
-        if !current_directory.has_item(&filename) {
-            break;
-        }
-        let file_extension = file.extension().and_then(OsStr::to_str).map(str::to_string);
-        let file_stem = file.file_stem().and_then(OsStr::to_str).map(str::to_string);
-
-        filename = match (file_stem, file_extension) {
-            (Some(file_stem), Some(file_extension)) => {
-                format!("{file_stem} ({count_index_for_duplicate_filename}).{file_extension}")
-            }
-            _ => format!("{original} ({count_index_for_duplicate_filename})"),
-        };
-
-        log::info!("Duplicate name, changing file name to {}", &filename);
-        count_index_for_duplicate_filename += 1;
-    }
-
-    let tokio_file = match tokio::fs::File::open(&local_path).await {
-        Ok(file) => file,
-        Err(error) => {
-            log::error!("Error on get tokio file, cancelling upload action, error: {error}");
-            return;
-        }
-    };
-
-    let total_size_for_stream = match tokio_file.metadata().await {
-        Ok(data) => Some(data.len() as usize),
-        Err(error) => {
-            log::error!("Error getting metadata: {:?}", error);
-            None
-        }
-    };
-
-    let file_stream = ReaderStream::new(tokio_file)
-        .filter_map(|x| async { x.ok() })
-        .map(|x| x.into());
-
-    match file_storage
-        .put_stream(&filename, total_size_for_stream, file_stream.boxed())
-        .await
-    {
-        Ok(mut upload_progress) => {
-            while let Some(upload_progress) = upload_progress.next().await {
-                match upload_progress {
-                    Progression::CurrentProgress {
-                        name,
-                        current,
-                        total,
-                    } => {
-                        log::info!("Written {} MB for {name}", current / 1024 / 1024);
-                        if let Some(total) = total {
-                            let mut selector_without_percentage =
-                                "document.getElementById('dropzone').value = '".to_owned();
-
-                            let percentage =
-                                ((((current as f64) / (total as f64)) * 100.) as usize).to_string();
-                            selector_without_percentage.push_str(&percentage);
-
-                            let ending_string = "% uploaded'";
-                            selector_without_percentage.push_str(ending_string);
-
-                            eval_script.eval(&selector_without_percentage);
-
-                            log::info!(
-                                "{}% completed",
-                                (((current as f64) / (total as f64)) * 100.) as usize
-                            )
-                        }
-                    }
-                    Progression::ProgressComplete { name, total } => {
-                        log::info!(
-                            "{name} has been uploaded with {} MB",
-                            total.unwrap_or_default() / 1024 / 1024
-                        );
-                    }
-                    Progression::ProgressFailed {
-                        name,
-                        last_size,
-                        error,
-                    } => {
-                        log::info!(
-                            "{name} failed to upload at {} MB due to: {}",
-                            last_size.unwrap_or_default(),
-                            error.unwrap_or_default()
-                        );
-                    }
-                }
-            }
-            match set_thumbnail_if_file_is_image(file_storage.clone(), filename.clone()).await {
-                Ok(success) => log::info!("{:?}", success), 
-                Err(error) => log::error!("Error on update thumbnail: {:?}", error), 
-            }  
-            log::info!("{:?} file uploaded!", &filename);
-        }, 
-        Err(error) => log::error!("Error when upload file: {:?}", error)
-        
-    }
-
-
-    
-}
-
-async fn set_thumbnail_if_file_is_image(
-    file_storage: Storage,
-    filename_to_save: String,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let item = file_storage.current_directory()?.get_item(&filename_to_save)?;
-    let parts_of_filename: Vec<&str> = filename_to_save.split('.').collect();
-
-    let file = file_storage.get_buffer(&filename_to_save).await?;
-
-    // Guarantee that is an image that has been uploaded
-    ImageReader::new(Cursor::new(&file))
-        .with_guessed_format()?
-        .decode()?;
-
-    // Since files selected are filtered to be jpg, jpeg, png or svg the last branch is not reachable
-    let mime = match parts_of_filename
-        .iter()
-        .map(|extension| extension.to_lowercase())
-        .last()
-    {
-        Some(m) => match m.as_str() {
-            "png" => IMAGE_PNG.to_string(),
-            "jpg" => IMAGE_JPEG.to_string(),
-            "jpeg" => IMAGE_JPEG.to_string(),
-            "svg" => IMAGE_SVG.to_string(),
-            &_ => "".to_string(),
-        },
-        None => "".to_string(),
-    };
-
-    if !file.is_empty() || !mime.is_empty() {
-        let prefix = format!("data:{};base64,", mime);
-        let base64_image = base64::encode(&file);
-        let img = prefix + base64_image.as_str();
-        item.set_thumbnail(&img);
-        Ok(format_args!("{} thumbnail updated with success!", item.name()).to_string())
-    } else {
-        Err(Box::from(Error::InvalidItem))
-    }
 }

--- a/src/components/main/files/upload/mod.rs
+++ b/src/components/main/files/upload/mod.rs
@@ -80,8 +80,6 @@ pub fn Upload<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                         file_storage.clone(),
                                         file_path.clone(),
                                         eval_script.clone(),
-                                        false,
-                                        None,
                                     )
                                     .await;
                                     tokio::time::sleep(std::time::Duration::from_millis(150)).await;
@@ -165,8 +163,8 @@ pub fn Upload<'a>(cx: Scope<'a, Props<'a>>) -> Element<'a> {
                                     async move {
                                         for file_path in &files_local_path {
                                             files_functions::upload_file(file_storage.clone(), file_path.clone(), 
-                                            eval_script.clone(), false,
-                                            None,).await;
+                                            eval_script.clone(),
+                                        ).await;
                                         }
                                     }
                                 });

--- a/src/ui_kit/Cargo.toml
+++ b/src/ui_kit/Cargo.toml
@@ -17,5 +17,8 @@ mime = "0.3.16"
 regex = "1.6.0"
 utils = { path = "../utils" }
 log = "0.4.17"
+tokio-util = { version = "0.7", features = ["full"] }
+image = "0.24.5"
+futures = "0.3"
 
 warp = { git = "https://github.com/Satellite-im/Warp", rev = "4744367eba199e688a913201bb5d5fcbc1eccbbc"}

--- a/src/ui_kit/src/folder/file_leave_folder.js
+++ b/src/ui_kit/src/folder/file_leave_folder.js
@@ -1,3 +1,3 @@
 var dropzone_element = document.getElementById("folder-id-folder")
-dropzone_element.style.background = "var(--theme-background-light)"
+dropzone_element.style.background = "transparent"
 dropzone_element.value = "Drop files here to upload"

--- a/src/ui_kit/src/folder/mod.rs
+++ b/src/ui_kit/src/folder/mod.rs
@@ -139,12 +139,13 @@ pub fn Folder(cx: Scope<Props>) -> Element {
                                             Err(error) => println!("Error adding file into directory: {error}"),
                                         };
                                                               
-                                    let file_leave_folder_js = include_str!("./file_leave_folder.js").replace("folder-id", &folder_id);
-                                    eval_script.eval(&file_leave_folder_js);
+                                    
                                 }
                         }
                             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                         }
+                        let file_leave_folder_js = include_str!("./file_leave_folder.js").replace("folder-id", &folder_id);
+                        eval_script.eval(&file_leave_folder_js);
                     }
                 });
             },

--- a/src/ui_kit/src/folder/mod.rs
+++ b/src/ui_kit/src/folder/mod.rs
@@ -116,9 +116,14 @@ pub fn Folder(cx: Scope<Props>) -> Element {
                                     let file = current_directory.get_item(&file_name).unwrap();
 
                                     file_name = files_functions::verify_duplicate_name(directory_target.clone(), 
-                                    file.name().clone(), PathBuf::from(file.name().clone()));
-
-                                    if let Ok(_) = file.rename(&file_name) {
+                                    file.name().clone(), PathBuf::from(file.name()));
+                                    if file_name.ne(&file.name()) {
+                                       if let Err(error) =  file.rename(&file_name) {
+                                        log::error!("Error renaming file to move into another folder: {error}");
+                                        return;
+                                       }
+                                    }
+                                      
                                         match directory_target.add_item(file.clone()) {
                                             Ok(_) => {
                                                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -133,7 +138,7 @@ pub fn Folder(cx: Scope<Props>) -> Element {
                                         },
                                             Err(error) => println!("Error adding file into directory: {error}"),
                                         };
-                                    }                              
+                                                              
                                     let file_leave_folder_js = include_str!("./file_leave_folder.js").replace("folder-id", &folder_id);
                                     eval_script.eval(&file_leave_folder_js);
                                 }

--- a/src/ui_kit/src/folder/mod.rs
+++ b/src/ui_kit/src/folder/mod.rs
@@ -1,7 +1,14 @@
-use dioxus::{prelude::*, core::to_owned, desktop::use_window};
+use std::{path::{PathBuf, Path}, ffi::OsStr, io::Cursor};
+
+use dioxus::{prelude::*, core::to_owned, desktop::{use_window, wry::webview::FileDropEvent, DesktopContext}};
 use dioxus_elements::KeyCode;
 use dioxus_heroicons::{outline::Shape, Icon};
-use utils::{Storage, DRAG_FILE_IN_APP_EVENT, DragFileInApp};
+use mime::*;
+use image::io::Reader as ImageReader;
+use tokio_util::io::ReaderStream;
+use futures::StreamExt;
+use utils::{Storage, DRAG_FILE_IN_APP_EVENT, DragFileInApp, DRAG_FILE_EVENT};
+use warp::{constellation::Progression, error::Error};
 use crate::context_menu::{ContextItem, ContextMenu};
 
 #[derive(PartialEq, Eq, Copy, Clone)]
@@ -31,7 +38,7 @@ pub fn Folder(cx: Scope<Props>) -> Element {
         State::Secondary => "secondary",
     };
 
-    let children = cx.props.children;
+    let mut children = cx.props.children;
     let dir_size = format_folder_size(cx.props.size);
 
 
@@ -72,6 +79,24 @@ pub fn Folder(cx: Scope<Props>) -> Element {
                                 break;
                             }
                             let drag_file_event_in_app = get_drag_file_event_in_app();
+                            let drag_file_out_app = get_drag_file_event_out_app();
+
+                            if let FileDropEvent::Dropped(files_local_path) = drag_file_out_app {
+                                *drag_over_folder.write_silent() = false;
+                                for file_path in &files_local_path {
+                                    upload_file(
+                                        file_storage.clone(),
+                                        file_path.clone(),
+                                        eval_script.clone(),
+                                        folder_name_complete_ref.read().clone(),
+                                    )
+                                    .await;
+                                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                                    log::info!("{} file uploaded!", file_path.to_string_lossy());
+                                }
+                                break;
+                            }
+
                             if let Some(file_name) = drag_file_event_in_app.file_name {
                                 let current_directory = file_storage.current_directory().unwrap_or_default();  
                                 let folder_name = folder_name_complete_ref.with(|name| name.clone());
@@ -223,6 +248,11 @@ fn get_drag_file_event_in_app() -> DragFileInApp {
     drag_file_event_in_app
 }
 
+fn get_drag_file_event_out_app() -> FileDropEvent {
+    let drag_file_event_out_app = DRAG_FILE_EVENT.read().clone();
+    drag_file_event_out_app
+}
+
 fn format_folder_size(folder_size: usize) -> String {
     if folder_size == 0 {
         return String::from("0 bytes");
@@ -260,4 +290,177 @@ fn format_folder_name_to_show(folder_name: String) -> String {
         };
     }
     new_folder_name
+}
+
+async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script: DesktopContext, folder_name: String) {
+    let mut filename = match file_path
+        .file_name()
+        .map(|file| file.to_string_lossy().to_string())
+    {
+        Some(file) => file,
+        None => return,
+    };
+
+    let local_path = Path::new(&file_path).to_string_lossy().to_string();
+    let mut count_index_for_duplicate_filename = 1;
+    let mut file_storage = file_storage.clone();
+    let original = filename.clone();
+    let file = PathBuf::from(&original);
+    
+    match file_storage.select(&folder_name) {
+        Ok(_) => (),
+        Err(error) => log::error!("Error selecting new current directory folder: {error}"),
+    };
+    let current_directory = match file_storage.current_directory() {
+        Ok(current_dir) => current_dir, 
+        _ => return
+    };
+    loop {
+        if !current_directory.has_item(&filename) {
+            break;
+        }
+        let file_extension = file.extension().and_then(OsStr::to_str).map(str::to_string);
+        let file_stem = file.file_stem().and_then(OsStr::to_str).map(str::to_string);
+
+        filename = match (file_stem, file_extension) {
+            (Some(file_stem), Some(file_extension)) => {
+                format!("{file_stem} ({count_index_for_duplicate_filename}).{file_extension}")
+            }
+            _ => format!("{original} ({count_index_for_duplicate_filename})"),
+        };
+
+        log::info!("Duplicate name, changing file name to {}", &filename);
+        count_index_for_duplicate_filename += 1;
+    }
+
+    let tokio_file = match tokio::fs::File::open(&local_path).await {
+        Ok(file) => file,
+        Err(error) => {
+            log::error!("Error on get tokio file, cancelling upload action, error: {error}");
+            return;
+        }
+    };
+
+    let total_size_for_stream = match tokio_file.metadata().await {
+        Ok(data) => Some(data.len() as usize),
+        Err(error) => {
+            log::error!("Error getting metadata: {:?}", error);
+            None
+        }
+    };
+
+    let file_stream = ReaderStream::new(tokio_file)
+        .filter_map(|x| async { x.ok() })
+        .map(|x| x.into());
+
+    match file_storage
+        .put_stream(&filename, total_size_for_stream, file_stream.boxed())
+        .await
+    {
+        Ok(mut upload_progress) => {
+            while let Some(upload_progress) = upload_progress.next().await {
+                match upload_progress {
+                    Progression::CurrentProgress {
+                        name,
+                        current,
+                        total,
+                    } => {
+                        log::info!("Written {} MB for {name}", current / 1024 / 1024);
+                        if let Some(total) = total {
+                            let mut selector_without_percentage =
+                                "document.getElementById('dropzone').value = '".to_owned();
+
+                            let percentage =
+                                ((((current as f64) / (total as f64)) * 100.) as usize).to_string();
+                            selector_without_percentage.push_str(&percentage);
+
+                            let ending_string = "% uploaded'";
+                            selector_without_percentage.push_str(ending_string);
+
+                            eval_script.eval(&selector_without_percentage);
+
+                            log::info!(
+                                "{}% completed",
+                                (((current as f64) / (total as f64)) * 100.) as usize
+                            )
+                        }
+                    }
+                    Progression::ProgressComplete { name, total } => {
+                        log::info!(
+                            "{name} has been uploaded with {} MB",
+                            total.unwrap_or_default() / 1024 / 1024
+                        );
+                    }
+                    Progression::ProgressFailed {
+                        name,
+                        last_size,
+                        error,
+                    } => {
+                        log::info!(
+                            "{name} failed to upload at {} MB due to: {}",
+                            last_size.unwrap_or_default(),
+                            error.unwrap_or_default()
+                        );
+                    }
+                }
+            }
+          
+            match set_thumbnail_if_file_is_image(file_storage.clone(), filename.clone()).await {
+                Ok(success) => log::info!("{:?}", success), 
+                Err(error) => log::error!("Error on update thumbnail: {:?}", error), 
+            }  
+
+            if let Err(error) = file_storage.go_back() {
+                log::error!("Error on go back a directory: {error}");
+            };
+            
+            log::info!("{:?} file uploaded!", &filename);
+        }, 
+        Err(error) => log::error!("Error when upload file: {:?}", error)
+        
+    }
+
+
+    
+}
+
+async fn set_thumbnail_if_file_is_image(
+    file_storage: Storage,
+    filename_to_save: String,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let item = file_storage.current_directory()?.get_item(&filename_to_save)?;
+    let parts_of_filename: Vec<&str> = filename_to_save.split('.').collect();
+
+    let file = file_storage.get_buffer(&filename_to_save).await?;
+
+    // Guarantee that is an image that has been uploaded
+    ImageReader::new(Cursor::new(&file))
+        .with_guessed_format()?
+        .decode()?;
+
+    // Since files selected are filtered to be jpg, jpeg, png or svg the last branch is not reachable
+    let mime = match parts_of_filename
+        .iter()
+        .map(|extension| extension.to_lowercase())
+        .last()
+    {
+        Some(m) => match m.as_str() {
+            "png" => IMAGE_PNG.to_string(),
+            "jpg" => IMAGE_JPEG.to_string(),
+            "jpeg" => IMAGE_JPEG.to_string(),
+            "svg" => IMAGE_SVG.to_string(),
+            &_ => "".to_string(),
+        },
+        None => "".to_string(),
+    };
+
+    if !file.is_empty() || !mime.is_empty() {
+        let prefix = format!("data:{};base64,", mime);
+        let base64_image = base64::encode(&file);
+        let img = prefix + base64_image.as_str();
+        item.set_thumbnail(&img);
+        Ok(format_args!("{} thumbnail updated with success!", item.name()).to_string())
+    } else {
+        Err(Box::from(Error::InvalidItem))
+    }
 }

--- a/src/ui_kit/src/folder/mod.rs
+++ b/src/ui_kit/src/folder/mod.rs
@@ -1,15 +1,9 @@
-use std::{path::{PathBuf, Path}, ffi::OsStr, io::Cursor};
-
-use dioxus::{prelude::*, core::to_owned, desktop::{use_window, wry::webview::FileDropEvent, DesktopContext}};
+use dioxus::{prelude::*, core::to_owned, desktop::{use_window, wry::webview::FileDropEvent}};
 use dioxus_elements::KeyCode;
 use dioxus_heroicons::{outline::Shape, Icon};
-use mime::*;
-use image::io::Reader as ImageReader;
-use tokio_util::io::ReaderStream;
-use futures::StreamExt;
 use utils::{Storage, DRAG_FILE_IN_APP_EVENT, DragFileInApp, DRAG_FILE_EVENT};
-use warp::{constellation::Progression, error::Error};
 use crate::context_menu::{ContextItem, ContextMenu};
+use utils::files_functions;
 
 #[derive(PartialEq, Eq, Copy, Clone)]
 pub enum State {
@@ -38,7 +32,7 @@ pub fn Folder(cx: Scope<Props>) -> Element {
         State::Secondary => "secondary",
     };
 
-    let mut children = cx.props.children;
+    let children = cx.props.children;
     let dir_size = format_folder_size(cx.props.size);
 
 
@@ -70,8 +64,9 @@ pub fn Folder(cx: Scope<Props>) -> Element {
                 use_eval(&cx)(&file_over_folder_js);
                 *drag_over_folder.write_silent() = true;
                 let file_storage = cx.props.storage.clone();
+                let update_current_dir = cx.props.update_current_dir.clone();
                 cx.spawn({
-                    to_owned![file_storage, folder_name_complete_ref, drag_over_folder, eval_script, folder_id];
+                    to_owned![file_storage, folder_name_complete_ref, drag_over_folder, eval_script, folder_id, update_current_dir];
                     async move {
                         loop {
                             let drop_allowed = *drag_over_folder.read();
@@ -82,19 +77,23 @@ pub fn Folder(cx: Scope<Props>) -> Element {
                             let drag_file_out_app = get_drag_file_event_out_app();
 
                             if let FileDropEvent::Dropped(files_local_path) = drag_file_out_app {
-                                *drag_over_folder.write_silent() = false;
-                                for file_path in &files_local_path {
-                                    upload_file(
-                                        file_storage.clone(),
-                                        file_path.clone(),
-                                        eval_script.clone(),
-                                        folder_name_complete_ref.read().clone(),
-                                    )
-                                    .await;
-                                    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-                                    log::info!("{} file uploaded!", file_path.to_string_lossy());
+                                if !files_local_path.is_empty() {
+                                    *drag_over_folder.write_silent() = false;
+                                    for file_path in &files_local_path {
+                                        files_functions::upload_file(
+                                            file_storage.clone(),
+                                            file_path.clone(),
+                                            eval_script.clone(), 
+                                            true, 
+                                            Some(folder_name_complete_ref.read().clone()),
+                                        )
+                                        .await;
+                                        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+                                        log::info!("{} file uploaded!", file_path.to_string_lossy());
+                                        update_current_dir.set(());
+                                    }
+                                    break;
                                 }
-                                break;
                             }
 
                             if let Some(file_name) = drag_file_event_in_app.file_name {
@@ -290,177 +289,4 @@ fn format_folder_name_to_show(folder_name: String) -> String {
         };
     }
     new_folder_name
-}
-
-async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script: DesktopContext, folder_name: String) {
-    let mut filename = match file_path
-        .file_name()
-        .map(|file| file.to_string_lossy().to_string())
-    {
-        Some(file) => file,
-        None => return,
-    };
-
-    let local_path = Path::new(&file_path).to_string_lossy().to_string();
-    let mut count_index_for_duplicate_filename = 1;
-    let mut file_storage = file_storage.clone();
-    let original = filename.clone();
-    let file = PathBuf::from(&original);
-    
-    match file_storage.select(&folder_name) {
-        Ok(_) => (),
-        Err(error) => log::error!("Error selecting new current directory folder: {error}"),
-    };
-    let current_directory = match file_storage.current_directory() {
-        Ok(current_dir) => current_dir, 
-        _ => return
-    };
-    loop {
-        if !current_directory.has_item(&filename) {
-            break;
-        }
-        let file_extension = file.extension().and_then(OsStr::to_str).map(str::to_string);
-        let file_stem = file.file_stem().and_then(OsStr::to_str).map(str::to_string);
-
-        filename = match (file_stem, file_extension) {
-            (Some(file_stem), Some(file_extension)) => {
-                format!("{file_stem} ({count_index_for_duplicate_filename}).{file_extension}")
-            }
-            _ => format!("{original} ({count_index_for_duplicate_filename})"),
-        };
-
-        log::info!("Duplicate name, changing file name to {}", &filename);
-        count_index_for_duplicate_filename += 1;
-    }
-
-    let tokio_file = match tokio::fs::File::open(&local_path).await {
-        Ok(file) => file,
-        Err(error) => {
-            log::error!("Error on get tokio file, cancelling upload action, error: {error}");
-            return;
-        }
-    };
-
-    let total_size_for_stream = match tokio_file.metadata().await {
-        Ok(data) => Some(data.len() as usize),
-        Err(error) => {
-            log::error!("Error getting metadata: {:?}", error);
-            None
-        }
-    };
-
-    let file_stream = ReaderStream::new(tokio_file)
-        .filter_map(|x| async { x.ok() })
-        .map(|x| x.into());
-
-    match file_storage
-        .put_stream(&filename, total_size_for_stream, file_stream.boxed())
-        .await
-    {
-        Ok(mut upload_progress) => {
-            while let Some(upload_progress) = upload_progress.next().await {
-                match upload_progress {
-                    Progression::CurrentProgress {
-                        name,
-                        current,
-                        total,
-                    } => {
-                        log::info!("Written {} MB for {name}", current / 1024 / 1024);
-                        if let Some(total) = total {
-                            let mut selector_without_percentage =
-                                "document.getElementById('dropzone').value = '".to_owned();
-
-                            let percentage =
-                                ((((current as f64) / (total as f64)) * 100.) as usize).to_string();
-                            selector_without_percentage.push_str(&percentage);
-
-                            let ending_string = "% uploaded'";
-                            selector_without_percentage.push_str(ending_string);
-
-                            eval_script.eval(&selector_without_percentage);
-
-                            log::info!(
-                                "{}% completed",
-                                (((current as f64) / (total as f64)) * 100.) as usize
-                            )
-                        }
-                    }
-                    Progression::ProgressComplete { name, total } => {
-                        log::info!(
-                            "{name} has been uploaded with {} MB",
-                            total.unwrap_or_default() / 1024 / 1024
-                        );
-                    }
-                    Progression::ProgressFailed {
-                        name,
-                        last_size,
-                        error,
-                    } => {
-                        log::info!(
-                            "{name} failed to upload at {} MB due to: {}",
-                            last_size.unwrap_or_default(),
-                            error.unwrap_or_default()
-                        );
-                    }
-                }
-            }
-          
-            match set_thumbnail_if_file_is_image(file_storage.clone(), filename.clone()).await {
-                Ok(success) => log::info!("{:?}", success), 
-                Err(error) => log::error!("Error on update thumbnail: {:?}", error), 
-            }  
-
-            if let Err(error) = file_storage.go_back() {
-                log::error!("Error on go back a directory: {error}");
-            };
-            
-            log::info!("{:?} file uploaded!", &filename);
-        }, 
-        Err(error) => log::error!("Error when upload file: {:?}", error)
-        
-    }
-
-
-    
-}
-
-async fn set_thumbnail_if_file_is_image(
-    file_storage: Storage,
-    filename_to_save: String,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let item = file_storage.current_directory()?.get_item(&filename_to_save)?;
-    let parts_of_filename: Vec<&str> = filename_to_save.split('.').collect();
-
-    let file = file_storage.get_buffer(&filename_to_save).await?;
-
-    // Guarantee that is an image that has been uploaded
-    ImageReader::new(Cursor::new(&file))
-        .with_guessed_format()?
-        .decode()?;
-
-    // Since files selected are filtered to be jpg, jpeg, png or svg the last branch is not reachable
-    let mime = match parts_of_filename
-        .iter()
-        .map(|extension| extension.to_lowercase())
-        .last()
-    {
-        Some(m) => match m.as_str() {
-            "png" => IMAGE_PNG.to_string(),
-            "jpg" => IMAGE_JPEG.to_string(),
-            "jpeg" => IMAGE_JPEG.to_string(),
-            "svg" => IMAGE_SVG.to_string(),
-            &_ => "".to_string(),
-        },
-        None => "".to_string(),
-    };
-
-    if !file.is_empty() || !mime.is_empty() {
-        let prefix = format!("data:{};base64,", mime);
-        let base64_image = base64::encode(&file);
-        let img = prefix + base64_image.as_str();
-        item.set_thumbnail(&img);
-        Ok(format_args!("{} thumbnail updated with success!", item.name()).to_string())
-    } else {
-        Err(Box::from(Error::InvalidItem))
-    }
 }

--- a/src/ui_kit/src/folder/mod.rs
+++ b/src/ui_kit/src/folder/mod.rs
@@ -113,10 +113,17 @@ pub fn Folder(cx: Scope<Props>) -> Element {
                                             Ok(dir) => dir,
                                             _ => return
                                     };
-                                    let file = current_directory.get_item(&file_name).unwrap();
+                                    
+                                    let file = match current_directory.get_item(&file_name) {
+                                        Ok(item) => item, 
+                                        Err(error) => {
+                                            log::error!("Error to get an item: {error}");
+                                            return;
+                                        },
+                                    };
 
                                     file_name = files_functions::verify_duplicate_name(directory_target.clone(), 
-                                    file.name().clone(), PathBuf::from(file.name()));
+                                    file.name(), PathBuf::from(file.name()));
                                     if file_name.ne(&file.name()) {
                                        if let Err(error) =  file.rename(&file_name) {
                                         log::error!("Error renaming file to move into another folder: {error}");

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -15,6 +15,13 @@ once_cell = "1.13"
 dirs = "4.0.0"
 clap = { version = "3.2", features = ["derive"] }
 anyhow = "1.0"
+base64 = "0.13.1"
+tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["full"] }
+image = "0.24.5"
+futures = "0.3"
+mime = "0.3.16"
+log = "0.4.17"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.1"

--- a/src/utils/src/files_functions.rs
+++ b/src/utils/src/files_functions.rs
@@ -9,7 +9,7 @@ use image::io::Reader as ImageReader;
 
 use crate::Storage;
 
-pub async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script: DesktopContext) {
+pub async fn upload_file(mut file_storage: Storage, file_path: PathBuf, eval_script: DesktopContext) {
     let mut filename = match file_path
         .file_name()
         .map(|file| file.to_string_lossy().to_string())
@@ -19,7 +19,6 @@ pub async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script:
     };
 
     let local_path = Path::new(&file_path).to_string_lossy().to_string();
-    let mut file_storage = file_storage.clone();
     let original = filename.clone();
     let file = PathBuf::from(&original);
 

--- a/src/utils/src/files_functions.rs
+++ b/src/utils/src/files_functions.rs
@@ -187,3 +187,64 @@ async fn set_thumbnail_if_file_is_image(
         Err(Box::from(Error::InvalidItem))
     }
 }
+
+pub fn format_item_size(item_size: usize) -> String {
+    if item_size == 0 {
+        return String::from("0 bytes");
+    }
+    let base_1024: f64 = 1024.0;
+    let size_f64: f64 = item_size as f64;
+
+    let i = (size_f64.log10() / base_1024.log10()).floor();
+    let size_formatted = size_f64 / base_1024.powf(i);
+
+    let item_size_suffix = ["bytes", "KB", "MB", "GB", "TB"][i as usize];
+    let mut size_formatted_string = format!(
+        "{size:.*} {size_suffix}",
+        1,
+        size = size_formatted,
+        size_suffix = item_size_suffix
+    );
+    if size_formatted_string.contains(".0") {
+        size_formatted_string = size_formatted_string.replace(".0", "");
+    }
+    size_formatted_string
+}
+
+pub fn format_item_name(item_name: String, file_kind: Option<String>, is_folder: bool) -> String {
+    let mut new_item_name = item_name.clone();
+    let item = PathBuf::from(&new_item_name);
+
+    if is_folder {
+        if new_item_name.len() > 10 {
+            new_item_name = match &new_item_name.get(0..5) {
+                Some(name_sliced) => format!(
+                    "{}...{}",
+                    name_sliced,
+                    &new_item_name[new_item_name.len() - 3..].to_string(),
+                ),
+                None => new_item_name.clone(),
+            };
+        }
+    } else {
+        let file_kind = file_kind.unwrap_or_default();
+        let file_stem = item
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .map(str::to_string)
+        .unwrap_or_default();
+
+    if file_stem.len() > 10 {
+        new_item_name = match &item_name.get(0..5) {
+            Some(name_sliced) => format!(
+                "{}...{}.{}",
+                name_sliced,
+                &file_stem[file_stem.len() - 3..].to_string(),
+                file_kind
+            ),
+            None => item_name.clone(),
+        };
+    }
+    }
+new_item_name
+}

--- a/src/utils/src/files_functions.rs
+++ b/src/utils/src/files_functions.rs
@@ -1,0 +1,189 @@
+use std::{path::{PathBuf, Path}, io::Cursor, ffi::OsStr};
+
+use dioxus::desktop::DesktopContext;
+use futures::StreamExt;
+use mime::*;
+use tokio_util::io::ReaderStream;
+use warp::{constellation::Progression, error::Error};
+use image::io::Reader as ImageReader;
+
+use crate::Storage;
+
+pub async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script: DesktopContext, drag_and_drop_on_target_folder: bool, folder_name: Option<String>) {
+    let mut filename = match file_path
+        .file_name()
+        .map(|file| file.to_string_lossy().to_string())
+    {
+        Some(file) => file,
+        None => return,
+    };
+
+    let local_path = Path::new(&file_path).to_string_lossy().to_string();
+    let mut count_index_for_duplicate_filename = 1;
+    let mut file_storage = file_storage.clone();
+    let original = filename.clone();
+    let file = PathBuf::from(&original);
+    let folder_name = folder_name.unwrap_or_default();
+
+    if drag_and_drop_on_target_folder && !folder_name.is_empty() {
+        match file_storage.select(&folder_name) {
+            Ok(_) => (),
+            Err(error) => log::error!("Error selecting new current directory folder: {error}"),
+        };
+    }
+
+    let current_directory = match file_storage.current_directory() {
+        Ok(current_dir) => current_dir, 
+        _ => return
+    };
+
+    loop {
+        if !current_directory.has_item(&filename) {
+            break;
+        }
+        let file_extension = file.extension().and_then(OsStr::to_str).map(str::to_string);
+        let file_stem = file.file_stem().and_then(OsStr::to_str).map(str::to_string);
+
+        filename = match (file_stem, file_extension) {
+            (Some(file_stem), Some(file_extension)) => {
+                format!("{file_stem} ({count_index_for_duplicate_filename}).{file_extension}")
+            }
+            _ => format!("{original} ({count_index_for_duplicate_filename})"),
+        };
+
+        log::info!("Duplicate name, changing file name to {}", &filename);
+        count_index_for_duplicate_filename += 1;
+    }
+
+    let tokio_file = match tokio::fs::File::open(&local_path).await {
+        Ok(file) => file,
+        Err(error) => {
+            log::error!("Error on get tokio file, cancelling upload action, error: {error}");
+            return;
+        }
+    };
+
+    let total_size_for_stream = match tokio_file.metadata().await {
+        Ok(data) => Some(data.len() as usize),
+        Err(error) => {
+            log::error!("Error getting metadata: {:?}", error);
+            None
+        }
+    };
+
+    let file_stream = ReaderStream::new(tokio_file)
+        .filter_map(|x| async { x.ok() })
+        .map(|x| x.into());
+
+    match file_storage
+        .put_stream(&filename, total_size_for_stream, file_stream.boxed())
+        .await
+    {
+        Ok(mut upload_progress) => {
+            while let Some(upload_progress) = upload_progress.next().await {
+                match upload_progress {
+                    Progression::CurrentProgress {
+                        name,
+                        current,
+                        total,
+                    } => {
+                        log::info!("Written {} MB for {name}", current / 1024 / 1024);
+                        if let Some(total) = total {
+                            let mut selector_without_percentage =
+                                "document.getElementById('dropzone').value = '".to_owned();
+
+                            let percentage =
+                                ((((current as f64) / (total as f64)) * 100.) as usize).to_string();
+                            selector_without_percentage.push_str(&percentage);
+
+                            let ending_string = "% uploaded'";
+                            selector_without_percentage.push_str(ending_string);
+
+                            eval_script.eval(&selector_without_percentage);
+
+                            log::info!(
+                                "{}% completed",
+                                (((current as f64) / (total as f64)) * 100.) as usize
+                            )
+                        }
+                    }
+                    Progression::ProgressComplete { name, total } => {
+                        log::info!(
+                            "{name} has been uploaded with {} MB",
+                            total.unwrap_or_default() / 1024 / 1024
+                        );
+                    }
+                    Progression::ProgressFailed {
+                        name,
+                        last_size,
+                        error,
+                    } => {
+                        log::info!(
+                            "{name} failed to upload at {} MB due to: {}",
+                            last_size.unwrap_or_default(),
+                            error.unwrap_or_default()
+                        );
+                    }
+                }
+            }
+            match set_thumbnail_if_file_is_image(file_storage.clone(), filename.clone()).await {
+                Ok(success) => log::info!("{:?}", success), 
+                Err(error) => log::error!("Error on update thumbnail: {:?}", error), 
+            }  
+
+            if drag_and_drop_on_target_folder {
+                if let Err(error) = file_storage.go_back() {
+                    log::error!("Error on go back a directory: {error}");
+                };
+            }
+
+            log::info!("{:?} file uploaded!", &filename);
+        }, 
+        Err(error) => log::error!("Error when upload file: {:?}", error)
+        
+    }
+
+
+    
+}
+
+async fn set_thumbnail_if_file_is_image(
+    file_storage: Storage,
+    filename_to_save: String,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let item = file_storage.current_directory()?.get_item(&filename_to_save)?;
+    let parts_of_filename: Vec<&str> = filename_to_save.split('.').collect();
+
+    let file = file_storage.get_buffer(&filename_to_save).await?;
+
+    // Guarantee that is an image that has been uploaded
+    ImageReader::new(Cursor::new(&file))
+        .with_guessed_format()?
+        .decode()?;
+
+    // Since files selected are filtered to be jpg, jpeg, png or svg the last branch is not reachable
+    let mime = match parts_of_filename
+        .iter()
+        .map(|extension| extension.to_lowercase())
+        .last()
+    {
+        Some(m) => match m.as_str() {
+            "png" => IMAGE_PNG.to_string(),
+            "jpg" => IMAGE_JPEG.to_string(),
+            "jpeg" => IMAGE_JPEG.to_string(),
+            "svg" => IMAGE_SVG.to_string(),
+            &_ => "".to_string(),
+        },
+        None => "".to_string(),
+    };
+
+    if !file.is_empty() || !mime.is_empty() {
+        let prefix = format!("data:{};base64,", mime);
+        let base64_image = base64::encode(&file);
+        let img = prefix + base64_image.as_str();
+        item.set_thumbnail(&img);
+        Ok(format_args!("{} thumbnail updated with success!", item.name()).to_string())
+    } else {
+        Err(Box::from(Error::InvalidItem))
+    }
+}

--- a/src/utils/src/files_functions.rs
+++ b/src/utils/src/files_functions.rs
@@ -9,7 +9,7 @@ use image::io::Reader as ImageReader;
 
 use crate::Storage;
 
-pub async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script: DesktopContext, drag_and_drop_on_target_folder: bool, folder_name: Option<String>) {
+pub async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script: DesktopContext) {
     let mut filename = match file_path
         .file_name()
         .map(|file| file.to_string_lossy().to_string())
@@ -23,14 +23,6 @@ pub async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script:
     let mut file_storage = file_storage.clone();
     let original = filename.clone();
     let file = PathBuf::from(&original);
-    let folder_name = folder_name.unwrap_or_default();
-
-    if drag_and_drop_on_target_folder && !folder_name.is_empty() {
-        match file_storage.select(&folder_name) {
-            Ok(_) => (),
-            Err(error) => log::error!("Error selecting new current directory folder: {error}"),
-        };
-    }
 
     let current_directory = match file_storage.current_directory() {
         Ok(current_dir) => current_dir, 
@@ -130,13 +122,6 @@ pub async fn upload_file(file_storage: Storage, file_path: PathBuf, eval_script:
                 Ok(success) => log::info!("{:?}", success), 
                 Err(error) => log::error!("Error on update thumbnail: {:?}", error), 
             }  
-
-            if drag_and_drop_on_target_folder {
-                if let Err(error) = file_storage.go_back() {
-                    log::error!("Error on go back a directory: {error}");
-                };
-            }
-
             log::info!("{:?} file uploaded!", &filename);
         }, 
         Err(error) => log::error!("Error when upload file: {:?}", error)

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod extensions;
 pub mod notifications;
 pub mod sounds;
+pub mod files_functions;
 
 use clap::Parser;
 use dioxus::desktop::wry::webview::FileDropEvent;
 use once_cell::sync::Lazy;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
+
 
 use warp::{constellation::Constellation, multipass::MultiPass, sync::RwLock};
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖
### 1. Upload files directly into a target folder with drag and drop from machine 

https://user-images.githubusercontent.com/63157656/208176329-1beb085b-65f0-45c5-88fb-82898b461ad1.mov

### 2. Add possibility to move a file into a folder, even if inside that folder there is a file with same name 


https://user-images.githubusercontent.com/63157656/208192590-bfc31ff7-1f52-4b44-8001-d02aac0f92a7.mov



### 3. Organize some repeated functions in just one file in utils, like upload file, format item size, format item name 
![image](https://user-images.githubusercontent.com/63157656/208176722-83ea1583-08f3-49a3-a628-1c4413ef81eb.png)
![image](https://user-images.githubusercontent.com/63157656/208176791-dd7b6578-570e-4bee-ac79-d8373d912882.png)
![image](https://user-images.githubusercontent.com/63157656/208176814-82cb1bfb-224c-4fd4-8ecf-ee022f0a5c93.png)



### Which issue(s) this PR fixes 🔨
- Resolve #593 
<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️
@phillsatellite It not work for windows

### Additional comments 🎤

