### PR TITLE
chore(read-me): add info

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ It's often necessary to reset your account for development, to do so just delete
 
 If you see something about cmake or protoc then you likely need to install those and get them in your path. Often times just restarting your shell helps. Other errors are fixed with updating packages `cargo update` or getting the nightly `rustup update; rustup default nightly` or stable `rustup update; rustup default stable` version of rust.
 
+If you have this error
+
+`Blocking waiting for file lock on package cache`
+
+the fix is
+
+`rm -rf ~/.cargo/.package-cache` 
+
 ## Debugging
 - run uplink as follows: `RUST_LOG=debug target/debug/uplink`
 - in another terminal (by default `~/.warp/logs`), tail the log file, follow it, and grep for `uplink`: `tail -f <file_name> | grep uplink`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

added info in read me related to 


If you have this error

`Blocking waiting for file lock on package cache`

the fix is

`rm -rf ~/.cargo/.package-cache` 